### PR TITLE
[BE] Usecase 인터페이스 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/common/Params.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/common/Params.java
@@ -1,0 +1,5 @@
+package com.ddbb.dingdong.application.common;
+
+public interface Params {
+    default boolean validate() { return true;}
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/common/UseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/common/UseCase.java
@@ -1,0 +1,5 @@
+package com.ddbb.dingdong.application.common;
+
+public interface UseCase<P extends Params, R> {
+    R execute(P param);
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/exception/APIError.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/exception/APIError.java
@@ -1,0 +1,20 @@
+package com.ddbb.dingdong.presentation.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface APIError {
+    String getDesc();
+    HttpStatus getStatus();
+
+    default String getMessage() {
+        return "[" + getStatus() + "] " + getDesc() + "(" + getCode() + ")";
+    }
+
+    default String getCode() {
+        return ((Enum<?>) this).name();
+    }
+
+    default APIException toException() {
+        return new APIException(this);
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/exception/APIException.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/exception/APIException.java
@@ -1,0 +1,10 @@
+package com.ddbb.dingdong.presentation.exception;
+
+public class APIException extends RuntimeException {
+    public APIError error;
+
+    public APIException(APIError error) {
+        super(error.getMessage());
+        this.error = error;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/exception/APIExceptionHandler.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/exception/APIExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.ddbb.dingdong.presentation.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class APIExceptionHandler extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(APIException.class)
+    public ResponseEntity<?> handleAPIException(APIException e) {
+        ErrorResponse response = new ErrorResponse(e.error.getStatus(), e.error.getDesc(), e.error.getCode(), LocalDateTime.now());
+
+        return ResponseEntity.status(e.error.getStatus())
+                .body(response);
+    }
+
+    record ErrorResponse(HttpStatus status, String desc, String code, LocalDateTime timestamp) {}
+}


### PR DESCRIPTION
## 관련 이슈
- [x] #70    

## 작업 내용

- [x] UseCase의 형식을 정의하여 인터페이스로 분리합니다.

## 상세 설명
- UseCase는 인터페이스는 execute 메소드를 오버라이딩해서 usecase 로직을 처리하도록 합니다.
- execute 메소드는 매개변수로 Params 인터페이스 타입을 필요로 하며 , 반환형또한 제네릭으로 사용자가 지정 할 수 있습니다
- Params 인터페이스를 구현한 객체는 validate()를 오버라이딩해야하며, 해당 매개변수를 검증하는 로직을 구현해야하고, 구현이 필요없을시 default로 true를 반환하도록 되어있습니다.

