### PR TITLE
Feat/#58 subscription manage

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/simulator/BusSimulatorFactory.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/BusSimulatorFactory.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.ddbb.dingdong.simulator.subscription.source.BusSimulator;
 import org.springframework.data.geo.Point;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/BusSubscriptionManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/BusSubscriptionManager.java
@@ -20,7 +20,9 @@ public class BusSubscriptionManager {
         StampedLock lock = lockMap.computeIfAbsent(busId, id -> new StampedLock());
         long stamp = lock.writeLock();
         Set<UserSubscription> set = subscribers.computeIfAbsent(busId, id -> new TreeSet<>());
-        set.add(subscription);
+        if (!set.contains(subscription)) {
+            set.add(subscription);
+        }
 
         publishers.computeIfPresent(busId, (key, publisher) -> {
            publisher.subscribe(subscription.getSubscriber());

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/BusSubscriptionManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/BusSubscriptionManager.java
@@ -1,0 +1,87 @@
+package com.ddbb.dingdong.simulator.subscription;
+
+import org.springframework.data.geo.Point;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.locks.StampedLock;
+
+@Service
+public class BusSubscriptionManager {
+    private final Map<Long, StampedLock> lockMap = new ConcurrentHashMap<>();
+    private final Map<Long, SubmissionPublisher<Point>> publishers = new HashMap<>();
+    private final Map<Long, Set<UserSubscription>> subscribers = new HashMap<>();
+
+    public BusSubscriptionManager() {}
+
+    public void subscribe(long busId, UserSubscription subscription) {
+        StampedLock lock = lockMap.computeIfAbsent(busId, id -> new StampedLock());
+        long stamp = lock.writeLock();
+        Set<UserSubscription> set = subscribers.computeIfAbsent(busId, id -> new TreeSet<>());
+        set.add(subscription);
+
+        publishers.computeIfPresent(busId, (key, publisher) -> {
+           publisher.subscribe(subscription.getSubscriber());
+           return publisher;
+        });
+        lock.unlockWrite(stamp);
+    }
+
+    public void addPublishers(Long busId, SubmissionPublisher<Point> publisher) {
+        StampedLock lock = lockMap.computeIfAbsent(busId, id -> new StampedLock());
+        long stamp = lock.writeLock();
+
+        if (!publishers.containsKey(busId)) {
+            Set<UserSubscription> subscriberSet = subscribers.computeIfAbsent(busId, (id) -> new TreeSet<>());
+            for (UserSubscription subscription : subscriberSet) {
+                publisher.subscribe(subscription.getSubscriber());
+            }
+            publishers.put(busId, publisher);
+        }
+        lock.unlockWrite(stamp);
+    }
+
+    public void unsubscribe(Long busId, Long userId) {
+        StampedLock lock = lockMap.computeIfAbsent(busId, id -> new StampedLock());
+        long stamp = lock.writeLock();
+
+        subscribers.computeIfPresent(busId, (id, subscriberSet) -> {
+            subscriberSet.removeIf(subscription -> {
+                if (subscription.getUserId().equals(userId)) {
+                    subscription.getSubscriber().cancel();
+                    return true;
+                }
+                return false;
+            });
+            return subscriberSet;
+        });
+        if (!(publishers.containsKey(busId) || subscribers.containsKey(busId))) {
+            lockMap.remove(busId);
+        }
+        lock.unlockWrite(stamp);
+    }
+
+    /**
+     * @param busId : 메모리에서 지울 publisher의 버스 아이디
+     * 매개변수로 들어온 버스아이디와 관련된 publisher과 관련된 자원(Subscriber 등)의 메모리를 해제합니다.
+     * Publisher에는 따로 close 메시지를 호출하지 않으므로, 이 메서드를 호출하고 따로 해당 publisher에 close 메서드를 호출해야 합니다.
+     * **/
+    public void cleanPublisher(Long busId) {
+        StampedLock lock = lockMap.computeIfAbsent(busId, id -> new StampedLock());
+        long stamp = lock.writeLock();
+
+        publishers.remove(busId);
+        Set<UserSubscription> subscriberSet = subscribers.remove(busId);
+        if (subscriberSet != null) {
+            for (UserSubscription subscription : subscriberSet) {
+                subscription.getSubscriber().cancel();
+            }
+        }
+        if (!(publishers.containsKey(busId) || subscribers.containsKey(busId))) {
+            lockMap.remove(busId);
+        }
+        lock.unlockWrite(stamp);
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/UserSubscription.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/UserSubscription.java
@@ -1,0 +1,26 @@
+package com.ddbb.dingdong.simulator.subscription;
+
+import com.ddbb.dingdong.simulator.subscription.subscriber.CancelableSubscriber;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.geo.Point;
+
+@Getter
+@AllArgsConstructor
+public class UserSubscription implements Comparable<UserSubscription> {
+    private Long userId;
+    private CancelableSubscriber<Point> subscriber;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof UserSubscription other) {
+            return userId.equals(other.userId);
+        }
+        return false;
+    }
+
+    @Override
+    public int compareTo(UserSubscription o) {
+        return userId.compareTo(o.userId);
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/BusPublisherFactory.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/BusPublisherFactory.java
@@ -1,0 +1,23 @@
+package com.ddbb.dingdong.simulator.subscription.publisher;
+
+import com.ddbb.dingdong.simulator.subscription.BusSubscriptionManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.geo.Point;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * 실제 버스 GPS 좌표를 받아오는 구현체도 이 팩터리 객체를 통해서 생성하여 생성 로직을 추상화
+ * **/
+@Service
+@RequiredArgsConstructor
+public class BusPublisherFactory {
+    private final BusSubscriptionManager manager;
+
+    public SubmissionPublisher<Point> createSimulator(Long busId, Supplier<Point> supplier) {
+        return new PeriodicBusPublisher<>(manager, busId, supplier, 1, 0, TimeUnit.SECONDS);
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/PeriodicBusPublisher.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/PeriodicBusPublisher.java
@@ -11,7 +11,7 @@ public class PeriodicBusPublisher<T> extends SubmissionPublisher<T> {
     private final ScheduledExecutorService scheduler;
     private final ScheduledFuture<?> periodicTask;
 
-    public PeriodicBusPublisher(
+    PeriodicBusPublisher(
             BusSubscriptionManager manager, long busId,
             Supplier<T> supplier, long period, long initialDelay, TimeUnit unit
     ) {

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/PeriodicBusPublisher.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/PeriodicBusPublisher.java
@@ -1,0 +1,28 @@
+package com.ddbb.dingdong.simulator.subscription.publisher;
+
+import java.util.concurrent.*;
+import java.util.function.Supplier;
+
+public class PeriodicBusPublisher<T> extends SubmissionPublisher<T> {
+    private final ScheduledExecutorService scheduler;
+    private final ScheduledFuture<?> periodicTask;
+
+    public PeriodicBusPublisher(Supplier<T> supplier, long period, long initialDelay, TimeUnit unit) {
+        super();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor();
+        this.periodicTask = scheduler.scheduleAtFixedRate(() -> {
+            T item = supplier.get();
+            if (item == null) {
+                this.close();
+                return;
+            }
+            submit(item);
+        }, initialDelay, period, unit);
+    }
+
+    public void close() {
+        periodicTask.cancel(false);
+        scheduler.shutdown();
+        super.close();
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/PeriodicBusPublisher.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/PeriodicBusPublisher.java
@@ -22,17 +22,21 @@ public class PeriodicBusPublisher<T> extends SubmissionPublisher<T> {
         this.periodicTask = scheduler.scheduleAtFixedRate(() -> {
             T item = supplier.get();
             if (item == null) {
-                this.close();
+                this.cleanRef();
                 return;
             }
             submit(item);
         }, initialDelay, period, unit);
     }
 
+    public void cleanRef() {
+        manager.removeRefOnly(busId);
+        this.close();
+    }
+
     public void close() {
         periodicTask.cancel(false);
         scheduler.shutdown();
-        manager.cleanPublisher(busId);
         super.close();
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/PeriodicBusPublisher.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/publisher/PeriodicBusPublisher.java
@@ -1,14 +1,23 @@
 package com.ddbb.dingdong.simulator.subscription.publisher;
 
+import com.ddbb.dingdong.simulator.subscription.BusSubscriptionManager;
+
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
 public class PeriodicBusPublisher<T> extends SubmissionPublisher<T> {
+    private final BusSubscriptionManager manager;
+    private final long busId;
     private final ScheduledExecutorService scheduler;
     private final ScheduledFuture<?> periodicTask;
 
-    public PeriodicBusPublisher(Supplier<T> supplier, long period, long initialDelay, TimeUnit unit) {
+    public PeriodicBusPublisher(
+            BusSubscriptionManager manager, long busId,
+            Supplier<T> supplier, long period, long initialDelay, TimeUnit unit
+    ) {
         super();
+        this.manager = manager;
+        this.busId = busId;
         this.scheduler = Executors.newSingleThreadScheduledExecutor();
         this.periodicTask = scheduler.scheduleAtFixedRate(() -> {
             T item = supplier.get();
@@ -23,6 +32,7 @@ public class PeriodicBusPublisher<T> extends SubmissionPublisher<T> {
     public void close() {
         periodicTask.cancel(false);
         scheduler.shutdown();
+        manager.cleanPublisher(busId);
         super.close();
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/source/BusSimulator.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/source/BusSimulator.java
@@ -3,12 +3,21 @@ package com.ddbb.dingdong.simulator.subscription.source;
 import org.springframework.data.geo.Point;
 
 import java.util.List;
+import java.util.function.Supplier;
 
-public class BusSimulator{
+public class BusSimulator implements Supplier<Point> {
     private final List<Point> simulatedPoints;
     private int currentPosition = 0;
 
     public BusSimulator(List<Point> simulatedPoints) {
         this.simulatedPoints = simulatedPoints;
+    }
+
+    @Override
+    public Point get() {
+        if (currentPosition >= simulatedPoints.size()) {
+            return null;
+        }
+        return simulatedPoints.get(currentPosition++);
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/source/BusSimulator.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/source/BusSimulator.java
@@ -1,9 +1,8 @@
-package com.ddbb.dingdong.simulator;
+package com.ddbb.dingdong.simulator.subscription.source;
 
 import org.springframework.data.geo.Point;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class BusSimulator{
     private final List<Point> simulatedPoints;

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/subscriber/CancelableSubscriber.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/subscriber/CancelableSubscriber.java
@@ -1,0 +1,11 @@
+package com.ddbb.dingdong.simulator.subscription.subscriber;
+
+import java.util.concurrent.Flow;
+
+public abstract class CancelableSubscriber<T> implements Flow.Subscriber<T> {
+    protected Flow.Subscription subscription;
+
+    public void cancel() {
+        this.subscription.cancel();
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/subscriber/StubConsoleSubscriber.java
+++ b/backend/src/main/java/com/ddbb/dingdong/simulator/subscription/subscriber/StubConsoleSubscriber.java
@@ -1,0 +1,32 @@
+package com.ddbb.dingdong.simulator.subscription.subscriber;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.geo.Point;
+
+import java.util.concurrent.Flow;
+
+@Slf4j
+public class StubConsoleSubscriber extends CancelableSubscriber<Point> {
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+        this.subscription = subscription;
+        this.subscription.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(Point item) {
+        System.out.println(item);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        log.debug(throwable.getMessage());
+        this.subscription.cancel();
+    }
+
+    @Override
+    public void onComplete() {
+        log.info("onComplete");
+        this.subscription.cancel();
+    }
+}

--- a/backend/src/test/java/com/ddbb/dingdong/bus/BusSimulatorTest.java
+++ b/backend/src/test/java/com/ddbb/dingdong/bus/BusSimulatorTest.java
@@ -1,0 +1,89 @@
+package com.ddbb.dingdong.bus;
+
+import com.ddbb.dingdong.simulator.subscription.BusSubscriptionManager;
+import com.ddbb.dingdong.simulator.subscription.UserSubscription;
+import com.ddbb.dingdong.simulator.subscription.publisher.BusPublisherFactory;
+import com.ddbb.dingdong.simulator.subscription.source.BusSimulator;
+import com.ddbb.dingdong.simulator.segment.RouteSegmentProvider;
+import com.ddbb.dingdong.simulator.segment.impl.StubRouteSegmentProvider;
+import com.ddbb.dingdong.simulator.BusSimulatorFactory;
+import com.ddbb.dingdong.simulator.subscription.subscriber.StubConsoleSubscriber;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.geo.Point;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SubmissionPublisher;
+
+class BusSimulatorTest {
+    private BusSubscriptionManager manager;
+    private BusPublisherFactory publisherFactory;
+    private BusSimulatorFactory factory;
+    private RouteSegmentProvider segmentProvider;
+
+    public BusSimulatorTest() {
+        this.manager = new BusSubscriptionManager();
+        this.publisherFactory = new BusPublisherFactory(manager);
+        this.segmentProvider = new StubRouteSegmentProvider();
+        this.factory = new BusSimulatorFactory(segmentProvider);
+
+    }
+
+    @Test()
+    void test() throws InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(13);
+        SubmissionPublisher<Point> publisher = publisherFactory.createSimulator(0L, factory.create(LocalDateTime.now()));
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        for (int i = 0; i < 3; i++) {
+            int finalI = i;
+            executor.submit(() -> {
+                try {
+                    countDownLatch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                this.manager.subscribe(0, new UserSubscription((long)finalI, new StubConsoleSubscriber()));
+            });
+        }
+        executor.submit(() -> {
+            try {
+                countDownLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            this.manager.addPublishers(0L, publisher);
+        });
+        executor.submit(() -> {
+            try {
+                countDownLatch.await();
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            this.manager.subscribe(0L,new UserSubscription((long)0, new StubConsoleSubscriber()));
+        });
+
+        executor.submit(() -> {
+            try {
+                countDownLatch.await();
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            this.manager.unsubscribe(0L,1L);
+        });
+        executor.submit(() -> {
+            try {
+                countDownLatch.await();
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            this.manager.cleanPublisher(0L);
+        });
+        countDownLatch.countDown();
+        Thread.sleep(5000);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- [ ] #60
    - [x] #22
    - [ ] #58

## 작업 내용
- [x] 새로운 버스 위치를 공급해주는 발행자와 이를 받아 처리하는 구독자를 관리하는 객체를 구현하였습니다.
  - [x] 구독자를 특정 발행자에 구독하는 기능 구현
    - 발행자가 없더라도 대기하도록 구현
    - 발행자 하나당 구독자는 하나가 되도록 구현 (userId, busId 기반)
  - [x] 특정 발행자에 대해서 구독을 취소하는 기능 구현
  - [ ] 발행자를 추가하는 기능 구현
      - [ ] 발행자 추가 시 대기하던 구독자들을 자동으로 구독하도록 하는 기능 구현
  - [ ] 발행자를 제거하는 기능 구현


## 클래스 다이어그램
```mermaid
classDiagram
    class BusSimulatorFactory {
        +create(time: LocalDateTime): List<BusSimulator>
    }

    class BusSimulator

    class Supplier {
        +get(): Point
    }

    class PeriodicBusPublisher {
        - manager: BusSubscriptionManager
    }

    class SubmissionPublisher

    class UserSubscription {
        - userId: Long,
        - subscriber: CancelableSubscriber
    }

    class BusSubscriptionManager {
        +addPublisher(busId: Long, publisher: SubmissionPublisher)
        +cleanPublisher(busId: Long)
        +subscribe(busId: Long, subscriber: UserSubscription)
        +unsubscribe(busId: Long, userId: Long)
    }

    class CancelableSubscriber

    class StubConsoleSender

    class Flow_Publisher

    class Flow_Subscriber {
        +onNext(point: Point)
    }

    BusSimulatorFactory --> BusSimulator : "creates"
    BusSimulatorFactory ..> BusSimulator : "<<create>>"
    BusSimulator ..> Supplier

    PeriodicBusPublisher --> Supplier
    PeriodicBusPublisher --|> SubmissionPublisher
    PeriodicBusPublisher --> BusSubscriptionManager

    SubmissionPublisher ..|> Flow_Publisher

    BusSubscriptionManager ..> SubmissionPublisher
    BusSubscriptionManager ..> CancelableSubscriber

    CancelableSubscriber --|> Flow_Subscriber
    StubConsoleSender --|> CancelableSubscriber
```

## 상세 설명
- BusSubscriptionManager.java에서, 유저가 특정 버스에 대해서 구독을 할 때, 같은 버스를 이미 구독하고 있다면 무시하고, 버스가 없더라도 일단 대기하도록 구현했습니다.
- BusSubscriptionManager.java에서, 특정 버스에 대한 채널이 만들어질 때, 이를 대기하고 있던 구독자들을 전부 구독시키도록 구현했습니다.
- BusSubscriptionManager.java에서, 유저가 특정 버스에 대해서 구독을 취소할 때, 구독한 버스가 있다면 처리하고 그렇지 않다면 무시하도록 구현했습니다.
  - 기본 Flow.Subscriber 인터페이스에서는 구독을 취소하는 메서드를 지원하지 않아, 이 메서드를 추가한 추상 클래스인 CancelableSubscriber을 사용하도록 했습니다.
    - onSubscription에서 받은 Subscription 객체를 필드로 참조하고 있다가, 외부에서 cancel 메서드 호출시 이를 subscription에 전달만 하도록 구현했습니다.
      - cancel 호출 시 SubmissionPublisher에 있는 Subscriber 리스트를 제거합니다.
  - 아직 SubscriptionManager의 Subscribers에서 Subscriber를 참조하고 있어, 이를 제거하는 코드를 구현했습니다.
- BusSubscriptionManager.java에서, 버스가 운행을 종료할 때, 구독 중인 구독자들을 모두 구독 해제하고, 참조 중인 Publisher, Subscriber 모두 제거하는 기능을 구현했습니다.
  - SubmissionPublisher의 cancel 에서는 내부적으로 보관하는 Subscription마다 onComplete 메시지를 날려, 상태를 변경하고, Subscription은 Subscriber들에게 complete 전파하여 처리합니다.
 
## 추후 수정사항
- 현재 Publisher는 버스 위치만 발행하지만, 정류장 별로 얼마나 남았는지 계산하는 Processor를 두어 도착까지 남은 시간도 구할 수 있게 할 계획입니다.

