### PR TITLE
[BE] 비밀번호 암호화 util 클래스 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/SHA512PasswordEncoder.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/SHA512PasswordEncoder.java
@@ -1,0 +1,57 @@
+package com.ddbb.dingdong.infrastructure.auth.encrypt;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class SHA512PasswordEncoder {
+    private static final String HASH_ALGORITHM = "SHA-512";
+    private static final int HASH_ITERATIONS = 12;
+    private static final int SALT_LENGTH = 16;
+
+    public String encode(String rawPassword) {
+        byte[] salt = generateSalt();
+        return encodePassword(rawPassword, salt, HASH_ITERATIONS);
+    }
+
+    public boolean matches(String rawPassword, String encryptedPassword) {
+        String[] parts = encryptedPassword.split("\\$");
+        if(parts.length != 2) { return false; }
+        int iterations = Integer.parseInt(parts[0]);
+        byte[] salt = Base64.getDecoder().decode(parts[1]);
+        String expectedHash = encodePassword(rawPassword, salt, iterations);
+
+        return expectedHash.equals(encryptedPassword);
+    }
+
+    private String encodePassword(String rawPassword, byte[] salt, int iterations) {
+        try {
+            MessageDigest md = MessageDigest.getInstance(HASH_ALGORITHM);
+
+            md.update(salt);
+            byte[] encryptedPassword = md.digest(rawPassword.getBytes(StandardCharsets.UTF_8));
+
+            for (int i = 0; i < (1 << iterations); i++) {
+                md.update(encryptedPassword);
+                encryptedPassword = md.digest();
+            }
+
+            String base64Salt = Base64.getEncoder().encodeToString(salt);
+            String base64Hash = Base64.getEncoder().encodeToString(encryptedPassword);
+            return iterations + "$" + base64Salt + "$" + base64Hash;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-512 algorithm not found", e);
+        }
+    }
+
+    private byte[] generateSalt() {
+        byte[] salt = new byte[SALT_LENGTH];
+        new SecureRandom().nextBytes(salt);
+        return salt;
+    }
+}

--- a/backend/src/test/java/com/ddbb/dingdong/auth/SHA512PasswordEncoderTest.java
+++ b/backend/src/test/java/com/ddbb/dingdong/auth/SHA512PasswordEncoderTest.java
@@ -1,0 +1,20 @@
+package com.ddbb.dingdong.auth;
+
+import com.ddbb.dingdong.infrastructure.auth.encrypt.SHA512PasswordEncoder;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SHA512PasswordEncoderTest {
+    private final SHA512PasswordEncoder SHA512PasswordEncoder = new SHA512PasswordEncoder();
+
+    @Test
+    @DisplayName("패스워드 암호화 테스트")
+    void testPasswordEncoder() {
+        String rawPassword = "abcd1234!@";
+        String encryptPassword = SHA512PasswordEncoder.encode(rawPassword);
+        System.out.println(encryptPassword);
+        Assertions.assertThat(SHA512PasswordEncoder.matches(rawPassword, encryptPassword)).isTrue();
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- [x] #76 

## 작업 내용
- [x] 해시 알고리즘은 SHA512를 사용하여 구현하였습니다.
- [x] 암호화된 결과를 Base64인코딩하였습니다.
- [x] 평문 비밀번호에 랜덤으로 생성된 salt값을 이어붙혀 보안 요소를 강화하였습니다.
- [x] key stretching 방식을 사용하여, 해당 암호화 방식을 4096번 반복해, rainbow table 공격에 대응할 수 있도록 보안을 강화하였습니다.
- [x] 해시화한 비밀번호에, salt값, 반복횟수를 이어붙혀 최종적으로 암호화된 비밀번호를 생성합니다.

## 암호화 된 비밀번호 형식

`{반복횟수}${base64Salt값}${비밀번호 해시 결과}`

### 예시
`12$abc$abcd`
이경우 반복횟수는 2^12 = 4096이고, salt값은 abc, 비밀번호 해시결과는 abcd입니다. 
참고로 base64는 $를 포함하지 않기때문에 구분자를 $로 정하게 되었습니다.

## salt을 db에 따로 저장시키지 않아도 되는가?
결론만 말하자면 큰 문제가 없습니다
https://jhkimmm.tistory.com/24
Spring Security의 BcryptPasswordEncoder도 salt값을 해시값과 함께 저장하고있다고 합니다.


 