### PR TITLE
[BE] 로그인 API 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/exception/APIErrorInfos.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/exception/APIErrorInfos.java
@@ -1,0 +1,19 @@
+package com.ddbb.dingdong.application.exception;
+
+import com.ddbb.dingdong.domain.common.exception.ErrorInfo;
+
+public enum APIErrorInfos implements ErrorInfo {
+    UNKNOWN("알 수 없는 에러입니다."),
+    ;
+
+    private final String desc;
+
+    APIErrorInfos(String desc) {
+        this.desc = desc;
+    }
+
+    @Override
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/auth/LoginUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/auth/LoginUseCase.java
@@ -1,0 +1,39 @@
+package com.ddbb.dingdong.application.usecase.auth;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.user.service.UserManagement;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoginUseCase implements UseCase<LoginUseCase.Param,Void> {
+    private final UserManagement userManagement;
+
+    @Override
+    public Void execute(Param param) {
+        param.validate();
+        String email = param.email;
+        String rawPassword = param.rawPassword;
+        userManagement.login(email, rawPassword);
+        return null;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private String email;
+        private String rawPassword;
+
+        @Override
+        public boolean validate() {
+            if (email.isBlank()) throw AuthInvalidParamErrors.REQUIRED_EMAIL.toException();
+            if (rawPassword.isBlank()) throw AuthInvalidParamErrors.REQUIRED_PASSWORD.toException();
+
+            return true;
+        }
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/LoginUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/LoginUseCase.java
@@ -1,4 +1,4 @@
-package com.ddbb.dingdong.application.usecase.auth;
+package com.ddbb.dingdong.application.usecase.user;
 
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
@@ -30,8 +30,8 @@ public class LoginUseCase implements UseCase<LoginUseCase.Param,Void> {
 
         @Override
         public boolean validate() {
-            if (email.isBlank()) throw AuthInvalidParamErrors.REQUIRED_EMAIL.toException();
-            if (rawPassword.isBlank()) throw AuthInvalidParamErrors.REQUIRED_PASSWORD.toException();
+            if (email.isBlank()) throw UserInvalidParamErrors.REQUIRED_EMAIL.toException();
+            if (rawPassword.isBlank()) throw UserInvalidParamErrors.REQUIRED_PASSWORD.toException();
 
             return true;
         }

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/UserInvalidParamErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/UserInvalidParamErrors.java
@@ -1,0 +1,26 @@
+package com.ddbb.dingdong.application.usecase.user;
+
+import com.ddbb.dingdong.application.exception.InvalidParamErrorInfo;
+
+public enum UserInvalidParamErrors implements InvalidParamErrorInfo {
+    REQUIRED_EMAIL("이메일이 설정되지 않았습니다.", "email"),
+    REQUIRED_PASSWORD("비밀번호가 설정되지 않았습니다.", "password"),
+    ;
+
+    private final String desc;
+    private final String field;
+
+    UserInvalidParamErrors(String desc, String field) {
+        this.desc = desc;
+        this.field = field;
+    }
+    @Override
+    public String getField() {
+        return field;
+    }
+
+    @Override
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.ddbb.dingdong.domain.user.repository;
+
+import com.ddbb.dingdong.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserErrors.java
@@ -1,0 +1,20 @@
+package com.ddbb.dingdong.domain.user.service;
+
+import com.ddbb.dingdong.domain.common.exception.ErrorInfo;
+
+public enum UserErrors implements ErrorInfo {
+    NOT_FOUND("해당 유저를 찾을 수 없습니다"),
+    NOT_MATCHED_PASSWORD("패스워드가 일치하지 않습니다"),
+    ;
+
+    private final String desc;
+
+    UserErrors(String desc) {
+        this.desc = desc;
+    }
+
+    @Override
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserManagement.java
@@ -1,0 +1,21 @@
+package com.ddbb.dingdong.domain.user.service;
+
+import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.repository.UserRepository;
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.AuthenticationManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserManagement {
+    private final UserRepository userRepository;
+    private final AuthenticationManager authenticationManager;
+
+    public void login(String email, String password) {
+        User user = userRepository.findByEmail(email).orElseThrow(AuthError.NOT_FOUND::toException);
+        if(!user.getPassword().equals(password)) throw AuthError.NOT_MATCHED_PASSWORD.toException();
+        authenticationManager.setAuthentication(new AuthUser(user.getId()));
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserManagement.java
@@ -14,8 +14,8 @@ public class UserManagement {
     private final AuthenticationManager authenticationManager;
 
     public void login(String email, String password) {
-        User user = userRepository.findByEmail(email).orElseThrow(AuthError.NOT_FOUND::toException);
-        if(!user.getPassword().equals(password)) throw AuthError.NOT_MATCHED_PASSWORD.toException();
+        User user = userRepository.findByEmail(email).orElseThrow(UserErrors.NOT_FOUND::toException);
+        if(!user.getPassword().equals(password)) throw UserErrors.NOT_MATCHED_PASSWORD.toException();
         authenticationManager.setAuthentication(new AuthUser(user.getId()));
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/UserLoginEndpoint.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/UserLoginEndpoint.java
@@ -1,8 +1,8 @@
 package com.ddbb.dingdong.presentation.endpoint.auth;
 
-import com.ddbb.dingdong.application.exception.APIErrors;
+import com.ddbb.dingdong.application.exception.APIErrorInfos;
 import com.ddbb.dingdong.application.exception.APIException;
-import com.ddbb.dingdong.application.usecase.auth.LoginUseCase;
+import com.ddbb.dingdong.application.usecase.user.LoginUseCase;
 import com.ddbb.dingdong.domain.common.exception.DomainException;
 import com.ddbb.dingdong.presentation.endpoint.auth.dto.LoginRequest;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +29,7 @@ public class UserLoginEndpoint {
         } catch (DomainException e) {
             throw new APIException(e, HttpStatus.UNAUTHORIZED);
         } catch (Exception e) {
-            throw new APIException(APIErrors.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new APIException(APIErrorInfos.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/UserLoginEndpoint.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/UserLoginEndpoint.java
@@ -1,0 +1,37 @@
+package com.ddbb.dingdong.presentation.endpoint.auth;
+
+import com.ddbb.dingdong.application.exception.APIErrors;
+import com.ddbb.dingdong.application.exception.APIException;
+import com.ddbb.dingdong.application.usecase.auth.LoginUseCase;
+import com.ddbb.dingdong.domain.common.exception.DomainException;
+import com.ddbb.dingdong.presentation.endpoint.auth.dto.LoginRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class UserLoginEndpoint {
+    private final LoginUseCase loginUseCase;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(
+            @RequestBody LoginRequest loginRequest
+    ) {
+        LoginUseCase.Param param = new LoginUseCase.Param(loginRequest.getEmail(), loginRequest.getPassword());
+        try {
+            loginUseCase.execute(param);
+        } catch (DomainException e) {
+            throw new APIException(e, HttpStatus.UNAUTHORIZED);
+        } catch (Exception e) {
+            throw new APIException(APIErrors.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.ddbb.dingdong.presentation.endpoint.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    private String email;
+    private String password;
+}


### PR DESCRIPTION
## 관련 이슈
- [x] #63 

## 작업 내용

- [x] LoginAPI 전체를 구현합니다.

## 상세 설명
- LoginUsecase.java에서, 유저가 건네준 값중 빈 값이 있는지 확인 후 비어 있다면 예외를 던지도록 구현 하였습니다.
- LoginEndpoint.java에서, 도메인 로직에서 발생한 예외를 try catch 잡아, 최종적으로 HttpStats.UNAUTHORIZED를 반환하도록 구현하였습니다.
- UserManagement.java의 login 메소드에서 로그인이 성공하면 HttpSession에 유저를 추가하도록 구현하였습니다.

## 추후 수정사항
- 현재 login 메소드에서는 평문 비밀번호와 비교를 하지만, 추후에 비밀번호를 encrypt하여 비교하는 방식을 도입해야 합니다. 

