### PR TITLE
[BE] - 유저 정보 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/exception/APIErrorInfos.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/exception/APIErrorInfos.java
@@ -1,0 +1,19 @@
+package com.ddbb.dingdong.application.exception;
+
+import com.ddbb.dingdong.domain.common.exception.ErrorInfo;
+
+public enum APIErrorInfos implements ErrorInfo {
+    UNKNOWN("알 수 없는 에러입니다."),
+    ;
+
+    private final String desc;
+
+    APIErrorInfos(String desc) {
+        this.desc = desc;
+    }
+
+    @Override
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/GetUserInfoUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/GetUserInfoUseCase.java
@@ -2,7 +2,12 @@ package com.ddbb.dingdong.application.usecase.user;
 
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.common.exception.DomainException;
+import com.ddbb.dingdong.domain.user.repository.UserReadOnlyRepository;
+import com.ddbb.dingdong.domain.user.repository.projection.UserStaticOnly;
+import com.ddbb.dingdong.domain.user.service.UserErrors;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,9 +15,18 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class GetUserInfoUseCase implements UseCase<GetUserInfoUseCase.Param, GetUserInfoUseCase.Result> {
+    private final UserReadOnlyRepository userRepository;
+
     @Override
     public Result execute(Param param) {
-        return null;
+        UserStaticOnly staticInfo = userRepository.findUserStaticInfoById(param.getUserId())
+                .orElseThrow(() -> new DomainException(UserErrors.NOT_FOUND));
+
+        return Result.builder()
+                .email(staticInfo.getEmail())
+                .userName(staticInfo.getUserName())
+                .schoolName(staticInfo.getSchoolName())
+                .build();
     }
 
     @Getter
@@ -22,6 +36,7 @@ public class GetUserInfoUseCase implements UseCase<GetUserInfoUseCase.Param, Get
     }
 
     @Getter
+    @Builder
     @AllArgsConstructor
     public static class Result {
         private String userName;

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/GetUserInfoUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/GetUserInfoUseCase.java
@@ -1,0 +1,31 @@
+package com.ddbb.dingdong.application.usecase.user;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserInfoUseCase implements UseCase<GetUserInfoUseCase.Param, GetUserInfoUseCase.Result> {
+    @Override
+    public Result execute(Param param) {
+        return null;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private Long userId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Result {
+        private String userName;
+        private String email;
+        private String schoolName;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/GetUserInfoUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/GetUserInfoUseCase.java
@@ -3,7 +3,7 @@ package com.ddbb.dingdong.application.usecase.user;
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
 import com.ddbb.dingdong.domain.common.exception.DomainException;
-import com.ddbb.dingdong.domain.user.repository.UserReadOnlyRepository;
+import com.ddbb.dingdong.domain.user.repository.UserQueryRepository;
 import com.ddbb.dingdong.domain.user.repository.projection.UserStaticOnly;
 import com.ddbb.dingdong.domain.user.service.UserErrors;
 import lombok.AllArgsConstructor;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class GetUserInfoUseCase implements UseCase<GetUserInfoUseCase.Param, GetUserInfoUseCase.Result> {
-    private final UserReadOnlyRepository userRepository;
+    private final UserQueryRepository userRepository;
 
     @Override
     public Result execute(Param param) {

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/LoginUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/LoginUseCase.java
@@ -1,0 +1,39 @@
+package com.ddbb.dingdong.application.usecase.user;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.user.service.UserManagement;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoginUseCase implements UseCase<LoginUseCase.Param,Void> {
+    private final UserManagement userManagement;
+
+    @Override
+    public Void execute(Param param) {
+        param.validate();
+        String email = param.email;
+        String rawPassword = param.rawPassword;
+        userManagement.login(email, rawPassword);
+        return null;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private String email;
+        private String rawPassword;
+
+        @Override
+        public boolean validate() {
+            if (email.isBlank()) throw UserInvalidParamErrors.REQUIRED_EMAIL.toException();
+            if (rawPassword.isBlank()) throw UserInvalidParamErrors.REQUIRED_PASSWORD.toException();
+
+            return true;
+        }
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/UserInvalidParamErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/UserInvalidParamErrors.java
@@ -1,0 +1,26 @@
+package com.ddbb.dingdong.application.usecase.user;
+
+import com.ddbb.dingdong.application.exception.InvalidParamErrorInfo;
+
+public enum UserInvalidParamErrors implements InvalidParamErrorInfo {
+    REQUIRED_EMAIL("이메일이 설정되지 않았습니다.", "email"),
+    REQUIRED_PASSWORD("비밀번호가 설정되지 않았습니다.", "password"),
+    ;
+
+    private final String desc;
+    private final String field;
+
+    UserInvalidParamErrors(String desc, String field) {
+        this.desc = desc;
+        this.field = field;
+    }
+    @Override
+    public String getField() {
+        return field;
+    }
+
+    @Override
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/User.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/User.java
@@ -17,6 +17,9 @@ public class User {
     private Long id = null;
 
     @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/User.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/User.java
@@ -28,10 +28,10 @@ public class User {
     @Column(updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "school_id")
     private School school;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private House house;
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserQueryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface UserReadOnlyRepository extends JpaRepository<User, Long> {
+public interface UserQueryRepository extends JpaRepository<User, Long> {
     @Query("SELECT u.name as userName, s.name as schoolName, u.email as email  FROM User u JOIN u.school s WHERE u.id = :id")
     Optional<UserStaticOnly> findUserStaticInfoById(Long id);
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserReadOnlyRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserReadOnlyRepository.java
@@ -1,0 +1,13 @@
+package com.ddbb.dingdong.domain.user.repository;
+
+import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.repository.projection.UserStaticOnly;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface UserReadOnlyRepository extends JpaRepository<User, Long> {
+    @Query("SELECT u.name as userName, s.name as schoolName, u.email as email  FROM User u JOIN u.school s WHERE u.id = :id")
+    Optional<UserStaticOnly> findUserStaticInfoById(Long id);
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.ddbb.dingdong.domain.user.repository;
+
+import com.ddbb.dingdong.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/projection/UserStaticOnly.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/projection/UserStaticOnly.java
@@ -1,0 +1,7 @@
+package com.ddbb.dingdong.domain.user.repository.projection;
+
+public interface UserStaticOnly {
+    String getUserName();
+    String getEmail();
+    String getSchoolName();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserErrors.java
@@ -1,0 +1,20 @@
+package com.ddbb.dingdong.domain.user.service;
+
+import com.ddbb.dingdong.domain.common.exception.ErrorInfo;
+
+public enum UserErrors implements ErrorInfo {
+    NOT_FOUND("해당 유저를 찾을 수 없습니다"),
+    NOT_MATCHED_PASSWORD("패스워드가 일치하지 않습니다"),
+    ;
+
+    private final String desc;
+
+    UserErrors(String desc) {
+        this.desc = desc;
+    }
+
+    @Override
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/service/UserManagement.java
@@ -1,0 +1,21 @@
+package com.ddbb.dingdong.domain.user.service;
+
+import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.repository.UserRepository;
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.AuthenticationManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserManagement {
+    private final UserRepository userRepository;
+    private final AuthenticationManager authenticationManager;
+
+    public void login(String email, String password) {
+        User user = userRepository.findByEmail(email).orElseThrow(UserErrors.NOT_FOUND::toException);
+        if(!user.getPassword().equals(password)) throw UserErrors.NOT_MATCHED_PASSWORD.toException();
+        authenticationManager.setAuthentication(new AuthUser(user.getId()));
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/UserLoginEndpoint.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/UserLoginEndpoint.java
@@ -1,0 +1,37 @@
+package com.ddbb.dingdong.presentation.endpoint.auth;
+
+import com.ddbb.dingdong.application.exception.APIErrorInfos;
+import com.ddbb.dingdong.application.exception.APIException;
+import com.ddbb.dingdong.application.usecase.user.LoginUseCase;
+import com.ddbb.dingdong.domain.common.exception.DomainException;
+import com.ddbb.dingdong.presentation.endpoint.auth.dto.LoginRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class UserLoginEndpoint {
+    private final LoginUseCase loginUseCase;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(
+            @RequestBody LoginRequest loginRequest
+    ) {
+        LoginUseCase.Param param = new LoginUseCase.Param(loginRequest.getEmail(), loginRequest.getPassword());
+        try {
+            loginUseCase.execute(param);
+        } catch (DomainException e) {
+            throw new APIException(e, HttpStatus.UNAUTHORIZED);
+        } catch (Exception e) {
+            throw new APIException(APIErrorInfos.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.ddbb.dingdong.presentation.endpoint.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/user/UserController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/user/UserController.java
@@ -16,12 +16,14 @@ import static com.ddbb.dingdong.application.usecase.user.GetUserInfoUseCase.*;
 
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/api/user")
+@RequestMapping("/api/users")
 public class UserController {
     private final GetUserInfoUseCase getUserInfoUseCase;
 
     @GetMapping("/me")
-    public Result getUserInfo(@LoginUser AuthUser authUser) {
+    public Result getUserInfo(
+            @LoginUser AuthUser authUser
+    ) {
         try {
             return getUserInfoUseCase.execute(new Param(authUser.id()));
         } catch (DomainException e) {

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/user/UserController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/user/UserController.java
@@ -27,9 +27,7 @@ public class UserController {
         try {
             return getUserInfoUseCase.execute(new Param(authUser.id()));
         } catch (DomainException e) {
-            throw new APIException(e, HttpStatus.UNAUTHORIZED);
-        } catch (Exception e) {
-            throw new APIException(APIErrorInfos.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new APIException(e, HttpStatus.NOT_FOUND);
         }
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/user/UserController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/user/UserController.java
@@ -1,0 +1,33 @@
+package com.ddbb.dingdong.presentation.endpoint.user;
+
+import com.ddbb.dingdong.application.exception.APIErrorInfos;
+import com.ddbb.dingdong.application.exception.APIException;
+import com.ddbb.dingdong.application.usecase.user.GetUserInfoUseCase;
+import com.ddbb.dingdong.domain.common.exception.DomainException;
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.annotation.LoginUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static com.ddbb.dingdong.application.usecase.user.GetUserInfoUseCase.*;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+    private final GetUserInfoUseCase getUserInfoUseCase;
+
+    @GetMapping("/me")
+    public Result getUserInfo(@LoginUser AuthUser authUser) {
+        try {
+            return getUserInfoUseCase.execute(new Param(authUser.id()));
+        } catch (DomainException e) {
+            throw new APIException(e, HttpStatus.UNAUTHORIZED);
+        } catch (Exception e) {
+            throw new APIException(APIErrorInfos.UNKNOWN, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/test/java/com/ddbb/dingdong/domain/user/repository/userRepository/GetStaticInfoTest.java
+++ b/backend/src/test/java/com/ddbb/dingdong/domain/user/repository/userRepository/GetStaticInfoTest.java
@@ -1,0 +1,46 @@
+package com.ddbb.dingdong.domain.user.repository.userRepository;
+
+import com.ddbb.dingdong.domain.user.entity.House;
+import com.ddbb.dingdong.domain.user.entity.School;
+import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.repository.UserReadOnlyRepository;
+import com.ddbb.dingdong.domain.user.repository.UserRepository;
+import com.ddbb.dingdong.domain.user.repository.projection.UserStaticOnly;
+import com.ddbb.dingdong.infrastructure.auth.encrypt.SHA512PasswordEncoder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@SpringBootTest
+class GetStaticInfoTest {
+    @Autowired
+    private UserReadOnlyRepository userReadOnlyRepository;
+    private SHA512PasswordEncoder encoder = new SHA512PasswordEncoder();
+    private String password = encoder.encode("123456");
+    private School school = new School(null, "seoul", "seoul", new BigDecimal("1.0"), new BigDecimal("1.0"));
+    private House house = new House(null, "address", new BigDecimal("1.0"), new BigDecimal("1.0"), null);
+    private User user = new User(null, "test", "test@test.com", password, LocalDateTime.now(), school, house);
+
+
+    @Test
+    @Transactional
+    public void success() {
+        User saved = userReadOnlyRepository.save(user);
+        Optional<UserStaticOnly> optional = this.userReadOnlyRepository.findUserStaticInfoById(saved.getId());
+
+        if (optional.isEmpty()) {
+            Assertions.fail();
+        }
+        UserStaticOnly userStaticOnly = optional.get();
+        Assertions.assertEquals(user.getEmail(), userStaticOnly.getEmail());
+        Assertions.assertEquals(user.getName(), userStaticOnly.getUserName());
+        Assertions.assertEquals(school.getName(), userStaticOnly.getSchoolName());
+    }
+}

--- a/backend/src/test/java/com/ddbb/dingdong/domain/user/repository/userRepository/GetStaticInfoTest.java
+++ b/backend/src/test/java/com/ddbb/dingdong/domain/user/repository/userRepository/GetStaticInfoTest.java
@@ -3,12 +3,10 @@ package com.ddbb.dingdong.domain.user.repository.userRepository;
 import com.ddbb.dingdong.domain.user.entity.House;
 import com.ddbb.dingdong.domain.user.entity.School;
 import com.ddbb.dingdong.domain.user.entity.User;
-import com.ddbb.dingdong.domain.user.repository.UserReadOnlyRepository;
-import com.ddbb.dingdong.domain.user.repository.UserRepository;
+import com.ddbb.dingdong.domain.user.repository.UserQueryRepository;
 import com.ddbb.dingdong.domain.user.repository.projection.UserStaticOnly;
 import com.ddbb.dingdong.infrastructure.auth.encrypt.SHA512PasswordEncoder;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,7 +19,7 @@ import java.util.Optional;
 @SpringBootTest
 class GetStaticInfoTest {
     @Autowired
-    private UserReadOnlyRepository userReadOnlyRepository;
+    private UserQueryRepository userQueryRepository;
     private SHA512PasswordEncoder encoder = new SHA512PasswordEncoder();
     private String password = encoder.encode("123456");
     private School school = new School(null, "seoul", "seoul", new BigDecimal("1.0"), new BigDecimal("1.0"));
@@ -32,8 +30,8 @@ class GetStaticInfoTest {
     @Test
     @Transactional
     public void success() {
-        User saved = userReadOnlyRepository.save(user);
-        Optional<UserStaticOnly> optional = this.userReadOnlyRepository.findUserStaticInfoById(saved.getId());
+        User saved = userQueryRepository.save(user);
+        Optional<UserStaticOnly> optional = this.userQueryRepository.findUserStaticInfoById(saved.getId());
 
         if (optional.isEmpty()) {
             Assertions.fail();


### PR DESCRIPTION
## 관련 이슈
- [x] #66

## 작업 내용

- [x] 유저 정보 조회 API 전체를 구현합니다.

## 상세 설명
- UserController.java에서, 도메인 로직에서 발생한 예외를 try catch 잡아, 최종적으로 HttpStats.UNAUTHORIZED를 반환하도록 구현하였습니다.
- UserReadOnlyRepository.java에서 필요한 필드만 가져올 수 있도록 인터페이스 projection을 이용해 구현하였습니다.
- GetUserInfoUseCase는 UserReadOnlyRepository을 직접 참조하여 구현합니다.
