### PR TITLE
Feat/#22 socket manager

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/CustomCloseStatus.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/CustomCloseStatus.java
@@ -1,0 +1,7 @@
+package com.ddbb.dingdong.infrastructure.webSocket;
+
+import org.springframework.web.socket.CloseStatus;
+
+public class CustomCloseStatus {
+    public static final CloseStatus DUPLICATE_WEBSOCKET = new CloseStatus(4000, "Duplicate websocket");
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/configuration/WebSocketConfig.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/configuration/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.ddbb.dingdong.infrastructure.webSocket.configuration;
+
+import com.ddbb.dingdong.infrastructure.webSocket.handler.AuthHandShakeInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final AuthHandShakeInterceptor authHandShakeInterceptor;
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "/ws")
+                .addInterceptors(authHandShakeInterceptor)
+                .setAllowedOriginPatterns("*");
+    }
+}
+

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/handler/AuthHandShakeInterceptor.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/handler/AuthHandShakeInterceptor.java
@@ -1,0 +1,32 @@
+package com.ddbb.dingdong.infrastructure.webSocket.handler;
+
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.AuthenticationManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeFailureException;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AuthHandShakeInterceptor implements HandshakeInterceptor {
+    private final AuthenticationManager authenticationManager;
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        AuthUser authUser = authenticationManager.getAuthentication();
+        if (authUser == null) {
+            throw new HandshakeFailureException("No session found");
+        }
+        attributes.put(SocketHandler.SESSION_NAME, authUser);
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/handler/SocketHandler.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/handler/SocketHandler.java
@@ -1,0 +1,48 @@
+package com.ddbb.dingdong.infrastructure.webSocket.handler;
+
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.webSocket.CustomCloseStatus;
+import com.ddbb.dingdong.infrastructure.webSocket.repository.SocketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Component
+@RequiredArgsConstructor
+public class SocketHandler extends TextWebSocketHandler {
+    final static String SESSION_NAME = "user";
+    private final SocketRepository socketRepository;
+
+    /**
+     * SocketRepository에 유저 하나당 하나의 WebSocketSession만 유지하도록
+     * 새롭게 웹 소켓이 연결이 되면, 기존 WebSocketSession을 새 WebSocketSession으로 대체하고,
+     * 기존 WebSocketSession을 close 함.
+     * **/
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        WebSocketSession concurrentSocket = new ConcurrentWebSocketSessionDecorator(session, 1000, 1024);
+        AuthUser authUser = (AuthUser)session.getAttributes().get(SESSION_NAME);
+
+        WebSocketSession webSocketSession = socketRepository.put(authUser.id(),  concurrentSocket);
+        if (webSocketSession != null) {
+            webSocketSession.close(CustomCloseStatus.DUPLICATE_WEBSOCKET);
+        }
+    }
+
+    @Override
+    public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus) throws Exception {
+        AuthUser authUser = (AuthUser)session.getAttributes().get(SESSION_NAME);
+
+        if (closeStatus != CustomCloseStatus.DUPLICATE_WEBSOCKET) {
+            socketRepository.remove(authUser.id());
+        }
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/repository/SocketRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/repository/SocketRepository.java
@@ -1,0 +1,34 @@
+package com.ddbb.dingdong.infrastructure.webSocket.repository;
+
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.AuthenticationManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequiredArgsConstructor
+public class SocketRepository {
+    private final Map<Long, WebSocketSession> storage = new ConcurrentHashMap<>();
+
+    public WebSocketSession get(Long userId) {
+        return storage.get(userId);
+    }
+
+    public WebSocketSession put(Long userId, WebSocketSession session) {
+        return storage.put(userId, session);
+    }
+
+    /**
+     * @param userId : 사용자 아이디
+     * 입력으로 넣은 사용자 아이디와 연결된 소켓 connection을 컬렉션에서 제거합니다.
+     * 반환된 WebSocketSession은 명시적으로 close 되어야 합니다.
+     * **/
+    public WebSocketSession remove(Long userId) throws IOException {
+        return storage.remove(userId);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- [x] #26
- [ ] #60 

## 작업 내용

- [x] 웹 소켓 세션을 관리하는 SocketHandler를 구현했습니다.

## 상세 설명
- SocketHandler에서 /ws로 접근하여 연결할 WebSocketSession을 관리합니다.
    - 유저 아이디마다 하나의 WebSocketSession 만을 유지합니다.
    - 이미 등록한 세션이 있다면, 새 연결로 교체하고, 기존 웹 소켓 세션은 close 합니다.
- AuthHandShakeInterceptor 에서 세션에 있는 Auth 정보를 불러와 WebSocketSession의 attribute에 복사합니다.

## 추후 수정사항
- 연결한 웹 세션을 이용해 구독하는 로직을 구현할 예정입니다.
