### PR TITLE
[BE] 유저 조회 쿼리 수정 및 User Entity 변경

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
@@ -2,9 +2,9 @@ package com.ddbb.dingdong.application.usecase.reservation;
 
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationStatus;
 import com.ddbb.dingdong.domain.reservation.repository.ReservationQueryRepository;
 import com.ddbb.dingdong.domain.reservation.repository.projection.UserReservationProjection;
-import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
 import com.ddbb.dingdong.presentation.endpoint.reservation.exchanges.ReservationCategory;
 import com.ddbb.dingdong.presentation.endpoint.reservation.exchanges.SortType;
 import lombok.AllArgsConstructor;
@@ -44,7 +44,7 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
         List<Result.ReservationInfo> reservationInfos = result.stream()
                 .map(r -> {
                     Result.ReservationInfo.OperationInfo operationInfo = null;
-                    if(OperationStatus.RUNNING.name().equals(r.getBusStatus())) {
+                    if(ReservationStatus.ALLOCATED.name().equals(r.getReservationStatus())) {
                         operationInfo = new Result.ReservationInfo.OperationInfo(
                                 r.getBusStatus(),
                                 r.getBusName(),

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -22,9 +22,9 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
                bs.expectedArrivalTime AS busStopArrivalTime,
                p.totalMinutes AS totalMinutes
         FROM Reservation r
-        LEFT JOIN Ticket t ON r.ticket.id = t.id
+        LEFT JOIN Ticket t ON r.id = t.reservation.id
         LEFT JOIN BusStop bs ON t.busStopId = bs.id
-        LEFT JOIN BusSchedule bs_arrival ON bs_arrival.id = t.busScheduleId AND bs_arrival.status = 'RUNNING'
+        LEFT JOIN BusSchedule bs_arrival ON bs_arrival.id = t.busScheduleId
         LEFT JOIN Bus b ON bs_arrival.bus.id = b.id
         LEFT JOIN Path p ON p.busSchedule.id = bs_arrival.id
         LEFT JOIN User u ON r.userId = :userId

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/User.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/User.java
@@ -28,10 +28,10 @@ public class User {
     @Column(updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
-    @ManyToOne(cascade = CascadeType.PERSIST)
+    @ManyToOne(cascade = CascadeType.PERSIST ,fetch = FetchType.LAZY)
     @JoinColumn(name = "school_id")
     private School school;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private Home home;
 }


### PR DESCRIPTION
### 수정 사항
- [x] 운행 중일때만 운행 정보를 가져오는게아니라, 운행 전, 운행 중 , 운행 완료 모두 운행정보를 가져오도록 변경.
- [x] User Entity에서 Home과 onetoone인데, home에만 FK가 생성되도록 연관관계 주인을 설정 