### PR TITLE
[FE] feat: 커스틈 nav 기능 추가

### DIFF
--- a/src/pages/Home/page.tsx
+++ b/src/pages/Home/page.tsx
@@ -7,11 +7,11 @@ import HomeHeader from "@/components/Headers/HomeHeader";
 import BusState from "@/pages/Home/component/BusState";
 import HomeSchool from "@/pages/Home/component/HomeSchool";
 import BusSelection from "@/pages/Home/component/BusSelection";
-import {useQueries} from "@tanstack/react-query";
-import queriesPath from "@/api/queries";
+import {usePathQueries} from "@/lib/customNav";
 
 export default function Page() {
-    const results = useQueries({ queries: queriesPath['/home'] });
+    const results = usePathQueries();
+
     const firstQuery = results[0];
 
     if (!firstQuery.isLoading && firstQuery.data) {


### PR DESCRIPTION
- usePathQueries(): 라우터 경로에 맞게 설정한 쿼리 배열을 실행 후 return
- navigate({state:}): navigate에 state 전달 가능