### PR TITLE
[BE] 소켓 매니저 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/CustomCloseStatus.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/CustomCloseStatus.java
@@ -1,0 +1,7 @@
+package com.ddbb.dingdong.infrastructure.webSocket;
+
+import org.springframework.web.socket.CloseStatus;
+
+public class CustomCloseStatus {
+    public static final CloseStatus DUPLICATE_WEBSOCKET = new CloseStatus(4000, "Duplicate websocket");
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/configuration/WebSocketConfig.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/configuration/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.ddbb.dingdong.infrastructure.webSocket.configuration;
+
+import com.ddbb.dingdong.infrastructure.webSocket.handler.AuthHandShakeInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final AuthHandShakeInterceptor authHandShakeInterceptor;
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "/ws")
+                .addInterceptors(authHandShakeInterceptor)
+                .setAllowedOriginPatterns("*");
+    }
+}
+

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/handler/AuthHandShakeInterceptor.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/handler/AuthHandShakeInterceptor.java
@@ -1,0 +1,32 @@
+package com.ddbb.dingdong.infrastructure.webSocket.handler;
+
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.AuthenticationManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeFailureException;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AuthHandShakeInterceptor implements HandshakeInterceptor {
+    private final AuthenticationManager authenticationManager;
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        AuthUser authUser = authenticationManager.getAuthentication();
+        if (authUser == null) {
+            throw new HandshakeFailureException("No session found");
+        }
+        attributes.put(SocketHandler.SESSION_NAME, authUser);
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/handler/SocketHandler.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/handler/SocketHandler.java
@@ -1,0 +1,48 @@
+package com.ddbb.dingdong.infrastructure.webSocket.handler;
+
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.webSocket.CustomCloseStatus;
+import com.ddbb.dingdong.infrastructure.webSocket.repository.SocketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Component
+@RequiredArgsConstructor
+public class SocketHandler extends TextWebSocketHandler {
+    final static String SESSION_NAME = "user";
+    private final SocketRepository socketRepository;
+
+    /**
+     * SocketRepository에 유저 하나당 하나의 WebSocketSession만 유지하도록
+     * 새롭게 웹 소켓이 연결이 되면, 기존 WebSocketSession을 새 WebSocketSession으로 대체하고,
+     * 기존 WebSocketSession을 close 함.
+     * **/
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        WebSocketSession concurrentSocket = new ConcurrentWebSocketSessionDecorator(session, 1000, 1024);
+        AuthUser authUser = (AuthUser)session.getAttributes().get(SESSION_NAME);
+
+        WebSocketSession webSocketSession = socketRepository.put(authUser.id(),  concurrentSocket);
+        if (webSocketSession != null) {
+            webSocketSession.close(CustomCloseStatus.DUPLICATE_WEBSOCKET);
+        }
+    }
+
+    @Override
+    public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus) throws Exception {
+        AuthUser authUser = (AuthUser)session.getAttributes().get(SESSION_NAME);
+
+        if (closeStatus != CustomCloseStatus.DUPLICATE_WEBSOCKET) {
+            socketRepository.remove(authUser.id());
+        }
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/repository/SocketRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/repository/SocketRepository.java
@@ -1,0 +1,34 @@
+package com.ddbb.dingdong.infrastructure.webSocket.repository;
+
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.AuthenticationManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequiredArgsConstructor
+public class SocketRepository {
+    private final Map<Long, WebSocketSession> storage = new ConcurrentHashMap<>();
+
+    public WebSocketSession get(Long userId) {
+        return storage.get(userId);
+    }
+
+    public WebSocketSession put(Long userId, WebSocketSession session) {
+        return storage.put(userId, session);
+    }
+
+    /**
+     * @param userId : 사용자 아이디
+     * 입력으로 넣은 사용자 아이디와 연결된 소켓 connection을 컬렉션에서 제거합니다.
+     * 반환된 WebSocketSession은 명시적으로 close 되어야 합니다.
+     * **/
+    public WebSocketSession remove(Long userId) throws IOException {
+        return storage.remove(userId);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #22

## 작업 내용
- 소켓을 관리하는 SocketRepository를 구현했습니다.
- 유저 아이디 하나당 하나의 소켓만을 유지합니다. 새로운 소켓 연결 요청이 들어온다면 기존 소켓은 연결을 해제하고 새 연결을 유지합니다.

## 작업 의도
- 스케쥴 서비스(경로 작성 로직)에서 많은 양의 데이터를 다루게 되므로,  메모리를 최대한 아끼는 것이 맞다고 판단했습니다.
- 소켓 하나를 가지고 여러 데이터를 보내게 되므로 보낼 때 대기해야 하는 시간이 있을 수 있지만 동시에 보내는 데이터는 많아야 2~3개 정도기 때문에 큰 문제는 되지 않는다고 생각했습니다.
