### PR TITLE
[BE] 시간대별 정류장 조회 API

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
@@ -1,23 +1,68 @@
 package com.ddbb.dingdong.application.usecase.bus;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.transportation.repository.BusScheduleQueryRepository;
+import com.ddbb.dingdong.domain.transportation.repository.projection.AvailableBusStopProjection;
+import com.ddbb.dingdong.domain.transportation.repository.projection.BusReservedSeatProjection;
+import com.ddbb.dingdong.domain.transportation.service.BusStopQueryService;
+import com.ddbb.dingdong.domain.user.repository.UserQueryRepository;
+import com.ddbb.dingdong.domain.user.repository.projection.HomeStationProjection;
+import com.ddbb.dingdong.domain.user.service.UserErrors;
+
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
+@Service
 @RequiredArgsConstructor
 public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, GetAvailableBusLine.Response> {
     private final BusScheduleQueryRepository busScheduleQueryRepository;
+    private final UserQueryRepository userQueryRepository;
+    private final BusStopQueryService busStopQueryService;
 
     @Override
     public Response execute(Param param) {
-        return null;
+        HomeStationProjection homeStation = userQueryRepository.findHomeStationLocationWithSchoolId(param.userId)
+                .orElseThrow(UserErrors.NOT_FOUND::toException);
+        List<AvailableBusStopProjection> busStops = busStopQueryService.findAvailableBusStops(
+                homeStation.getSchoolId(),
+                param.direction,
+                param.time,
+                homeStation.getStationLongitude(),
+                homeStation.getStationLatitude()
+        );
+        List<Long> busIds = busStops.stream().map(AvailableBusStopProjection::getBusScheduleId).toList();
+        Map<Long, Long> reservedCount = busScheduleQueryRepository.findReservedSeatCount(busIds)
+                .stream()
+                .collect(Collectors.toMap(BusReservedSeatProjection::getBusScheduleId, BusReservedSeatProjection::getReservedSeatCount));
+
+        List<Response.Item> items = busStops.stream().map(busStop -> {
+            int count = Math.toIntExact(reservedCount.get(busStop.getBusScheduleId()));
+            Response.BusStopInfo busStopInfo = Response.BusStopInfo.builder()
+                    .name(busStop.getBusStopName())
+                    .time(busStop.getBusStopTime())
+                    .latitude(busStop.getLatitude())
+                    .longitude(busStop.getLongitude())
+                    .build();
+            Response.BusInfo busInfo = Response.BusInfo.builder()
+                    .name(busStop.getBusName())
+                    .reservedSeat(count)
+                    .totalSeat(15)
+                    .build();
+            return new Response.Item(busStop.getPathId(), busStopInfo, busInfo);
+        })
+        .toList();
+        return new Response(items);
     }
 
     @Getter
@@ -36,11 +81,13 @@ public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, G
         @Getter
         @AllArgsConstructor
         public static class Item {
+            private Long pathId;
             private BusStopInfo busStop;
             private BusInfo busInfo;
         }
 
         @Getter
+        @Builder
         @AllArgsConstructor
         public static class BusStopInfo {
             private String name;
@@ -50,6 +97,7 @@ public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, G
         }
 
         @Getter
+        @Builder
         @AllArgsConstructor
         public static class BusInfo {
             private String name;

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
@@ -1,0 +1,60 @@
+package com.ddbb.dingdong.application.usecase.bus;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.transportation.repository.BusScheduleQueryRepository;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, GetAvailableBusLine.Response> {
+    private final BusScheduleQueryRepository busScheduleQueryRepository;
+
+    @Override
+    public Response execute(Param param) {
+        return null;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private Long userId;
+        private LocalDateTime time;
+        private Direction direction;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+        private List<Item> result;
+
+        @Getter
+        @AllArgsConstructor
+        public static class Item {
+            private BusStopInfo busStop;
+            private BusInfo busInfo;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        public static class BusStopInfo {
+            private String name;
+            private LocalDateTime time;
+            private Double longitude;
+            private Double latitude;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        public static class BusInfo {
+            private String name;
+            private int reservedSeat;
+            private int totalSeat;
+        }
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
@@ -59,7 +59,7 @@ public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, G
                     .reservedSeat(count)
                     .totalSeat(15)
                     .build();
-            return new Response.Item(busStop.getPathId(), busStopInfo, busInfo);
+            return new Response.Item(busStop.getBusScheduleId(), busStopInfo, busInfo);
         })
         .toList();
         return new Response(items);
@@ -81,7 +81,7 @@ public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, G
         @Getter
         @AllArgsConstructor
         public static class Item {
-            private Long pathId;
+            private Long busScheduleId;
             private BusStopInfo busStop;
             private BusInfo busInfo;
         }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleQueryRepository.java
@@ -1,6 +1,7 @@
 package com.ddbb.dingdong.domain.transportation.repository;
 
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
+import com.ddbb.dingdong.domain.transportation.repository.projection.BusReservedSeatProjection;
 import com.ddbb.dingdong.domain.transportation.repository.projection.ScheduleTimeProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +17,13 @@ public interface BusScheduleQueryRepository extends JpaRepository<BusSchedule, L
 
     @Query("SELECT DISTINCT bs.departureTime as time FROM BusSchedule bs WHERE bs.schoolId = :schoolId and bs.status = 'READY'")
     List<ScheduleTimeProjection> findAvailableGoHomeBusTime(@Param("schoolId") Long schoolId);
+
+    @Query("SELECT COUNT(t.id) as reservedSeatCount , bs.id as busScheduleId " +
+            "FROM Ticket t " +
+            "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
+            "JOIN Reservation r ON t.id = r.ticket.id " +
+            "WHERE bs.id in :busScheduleIds " +
+            "AND r.status != 'CANCELED' " +
+            "GROUP BY bs.id")
+    List<BusReservedSeatProjection> findReservedSeatCount(@Param("busScheduleIds") List<Long> busScheduleIds);
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
@@ -13,11 +13,10 @@ import java.util.List;
 @Repository
 public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
     @Query("SELECT bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
-            "bst.expectedArrivalTime as busStopTime, b.name as busName, p.id as pathId, bs.id as busScheduleId " +
+            "bst.expectedArrivalTime as busStopTime, b.name as busName, bs.id as busScheduleId " +
             "FROM BusStop bst " +
             "JOIN Ticket t ON t.busStopId = bst.id " +
             "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
-            "JOIN Path p ON p.busSchedule.id = bs.id  " +
             "JOIN Bus b ON b.id = bs.bus.id " +
             "WHERE bs.departureTime = :departureTime AND bs.schoolId = :schoolId " +
             "AND bs.status = 'READY'")
@@ -27,11 +26,10 @@ public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
     );
 
     @Query("SELECT bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
-            "bst.expectedArrivalTime as busStopTime, b.name as busName, p.id as pathId, bs.id as busScheduleId " +
+            "bst.expectedArrivalTime as busStopTime, b.name as busName, bs.id as busScheduleId " +
             "FROM BusStop bst " +
             "JOIN Ticket t ON t.busStopId = bst.id " +
             "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
-            "JOIN Path p ON p.busSchedule.id = bs.id  " +
             "JOIN Bus b ON b.id = bs.bus.id " +
             "WHERE bs.arrivalTime = :arrivalTime AND bs.schoolId = :schoolId " +
             "AND bs.status = 'READY'")

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
@@ -1,0 +1,44 @@
+package com.ddbb.dingdong.domain.transportation.repository;
+
+import com.ddbb.dingdong.domain.transportation.entity.BusStop;
+import com.ddbb.dingdong.domain.transportation.repository.projection.AvailableBusStopProjection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
+    @Query("SELECT bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
+            "bst.expectedArrivalTime as busStopTime, b.name as busName, p.id as pathId, bs.id as busScheduleId " +
+            "FROM BusStop bst " +
+            "JOIN Ticket t ON t.busStopId = bst.id " +
+            "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
+            "JOIN Path p ON p.busSchedule.id = bs.id  " +
+            "JOIN Bus b ON b.id = bs.bus.id " +
+            "WHERE bs.departureTime = :departureTime AND bs.schoolId = :schoolId " +
+            "AND bs.status = 'READY'")
+    List<AvailableBusStopProjection> findAvailableGoHomeBusStop(
+            @Param("departureTime") LocalDateTime departureTime,
+            @Param("schoolId") Long schoolId
+    );
+
+    @Query("SELECT bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
+            "bst.expectedArrivalTime as busStopTime, b.name as busName, p.id as pathId, bs.id as busScheduleId " +
+            "FROM BusStop bst " +
+            "JOIN Ticket t ON t.busStopId = bst.id " +
+            "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
+            "JOIN Path p ON p.busSchedule.id = bs.id  " +
+            "JOIN Bus b ON b.id = bs.bus.id " +
+            "WHERE bs.arrivalTime = :arrivalTime AND bs.schoolId = :schoolId " +
+            "AND bs.status = 'READY'")
+    List<AvailableBusStopProjection>  findAvailableGoSchoolBusStop(
+            @Param("arrivalTime") LocalDateTime arrivalTime,
+            @Param("schoolId") Long schoolId
+    );
+
+
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
@@ -1,0 +1,13 @@
+package com.ddbb.dingdong.domain.transportation.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface AvailableBusStopProjection {
+    Long getPathId();
+    LocalDateTime getBusStopTime();
+    String getBusStopName();
+    Double getLongitude();
+    Double getLatitude();
+    String getBusName();
+    Long getBusScheduleId();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
@@ -3,7 +3,6 @@ package com.ddbb.dingdong.domain.transportation.repository.projection;
 import java.time.LocalDateTime;
 
 public interface AvailableBusStopProjection {
-    Long getPathId();
     LocalDateTime getBusStopTime();
     String getBusStopName();
     Double getLongitude();

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/BusReservedSeatProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/BusReservedSeatProjection.java
@@ -1,0 +1,6 @@
+package com.ddbb.dingdong.domain.transportation.repository.projection;
+
+public interface BusReservedSeatProjection {
+    Long getBusScheduleId();
+    Long getReservedSeatCount();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
@@ -1,20 +1,31 @@
 package com.ddbb.dingdong.domain.transportation.service;
 
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+import lombok.Getter;
+import org.springframework.stereotype.Service;
+
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.transportation.repository.BusStopQueryRepository;
 import com.ddbb.dingdong.domain.transportation.repository.projection.AvailableBusStopProjection;
 import com.ddbb.dingdong.util.GeoUtil;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class BusStopQueryService {
     private static final int THRESHOLD_METER = 1000;
+
+    public record AvailableBusStopDistance(AvailableBusStopProjection busStop, double distance)
+            implements Comparable<AvailableBusStopDistance> {
+        @Override
+        public int compareTo(AvailableBusStopDistance o) {
+            return Double.compare(this.distance, o.distance);
+        }
+    }
 
     private final BusStopQueryRepository busStopQueryRepository;
 
@@ -25,31 +36,14 @@ public class BusStopQueryService {
             case TO_HOME -> busStopQueryRepository.findAvailableGoHomeBusStop(time, schoolId);
             case TO_SCHOOL -> busStopQueryRepository.findAvailableGoSchoolBusStop(time, schoolId);
         };
-        Map<Long, List<AvailableBusStopProjection>> grouped = projections.stream()
-                .collect(Collectors.groupingBy(AvailableBusStopProjection::getPathId, Collectors.toList()
-        ));
-
-        List<AvailableBusStopProjection> result = new ArrayList<>();
-        for (List<AvailableBusStopProjection> group : grouped.values()) {
-            if (group.isEmpty()) continue;
-
-            AvailableBusStopProjection minItem = group.get(0);
-            double minDistance = GeoUtil.haversine(latitude, longitude, minItem.getLatitude(), minItem.getLongitude());
-            int itemCount = group.size();
-            for (int i = 1; i < itemCount; i++) {
-                AvailableBusStopProjection item = group.get(i);
-
-                double currentDistance = GeoUtil.haversine(latitude, longitude, item.getLatitude(), item.getLongitude());
-                if (currentDistance < minDistance) {
-                    minDistance = currentDistance;
-                    minItem = item;
-                }
-            }
-            if (minDistance > THRESHOLD_METER) {
-                continue;
-            }
-            result.add(minItem);
-        }
-        return result;
+        return projections.stream()
+            .map(projection -> {
+                double distance = GeoUtil.haversine(latitude, longitude, projection.getLatitude(), projection.getLongitude());
+                return new AvailableBusStopDistance(projection, distance);
+            })
+            .filter(item -> item.distance() <= THRESHOLD_METER)
+            .sorted(Comparator.comparingDouble(AvailableBusStopDistance::distance))
+            .map(AvailableBusStopDistance::busStop)
+            .toList();
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
@@ -3,8 +3,11 @@ package com.ddbb.dingdong.domain.transportation.service;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
+
 import org.springframework.stereotype.Service;
 
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
@@ -42,8 +45,14 @@ public class BusStopQueryService {
                 return new AvailableBusStopDistance(projection, distance);
             })
             .filter(item -> item.distance() <= THRESHOLD_METER)
-            .sorted(Comparator.comparingDouble(AvailableBusStopDistance::distance))
-            .map(AvailableBusStopDistance::busStop)
-            .toList();
+            .collect(Collectors.groupingBy(
+                    item -> item.busStop().getBusScheduleId(),
+                    Collectors.minBy(Comparator.comparingDouble(AvailableBusStopDistance::distance))
+            ))
+                .values()
+                .stream()
+                .filter(Optional::isPresent)
+                .map(item -> item.get().busStop())
+                .toList();
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
@@ -1,0 +1,55 @@
+package com.ddbb.dingdong.domain.transportation.service;
+
+import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.transportation.repository.BusStopQueryRepository;
+import com.ddbb.dingdong.domain.transportation.repository.projection.AvailableBusStopProjection;
+import com.ddbb.dingdong.util.GeoUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BusStopQueryService {
+    private static final int THRESHOLD_METER = 1000;
+
+    private final BusStopQueryRepository busStopQueryRepository;
+
+    public List<AvailableBusStopProjection> findAvailableBusStops(
+            Long schoolId, Direction direction, LocalDateTime time, Double longitude, Double latitude
+    ) {
+        List<AvailableBusStopProjection> projections = switch (direction) {
+            case TO_HOME -> busStopQueryRepository.findAvailableGoHomeBusStop(time, schoolId);
+            case TO_SCHOOL -> busStopQueryRepository.findAvailableGoSchoolBusStop(time, schoolId);
+        };
+        Map<Long, List<AvailableBusStopProjection>> grouped = projections.stream()
+                .collect(Collectors.groupingBy(AvailableBusStopProjection::getPathId, Collectors.toList()
+        ));
+
+        List<AvailableBusStopProjection> result = new ArrayList<>();
+        for (List<AvailableBusStopProjection> group : grouped.values()) {
+            if (group.isEmpty()) continue;
+
+            AvailableBusStopProjection minItem = group.get(0);
+            double minDistance = GeoUtil.haversine(latitude, longitude, minItem.getLatitude(), minItem.getLongitude());
+            int itemCount = group.size();
+            for (int i = 1; i < itemCount; i++) {
+                AvailableBusStopProjection item = group.get(i);
+
+                double currentDistance = GeoUtil.haversine(latitude, longitude, item.getLatitude(), item.getLongitude());
+                if (currentDistance < minDistance) {
+                    minDistance = currentDistance;
+                    minItem = item;
+                }
+            }
+            if (minDistance > THRESHOLD_METER) {
+                continue;
+            }
+            result.add(minItem);
+        }
+        return result;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserQueryRepository.java
@@ -2,6 +2,7 @@ package com.ddbb.dingdong.domain.user.repository;
 
 import com.ddbb.dingdong.domain.user.entity.User;
 import com.ddbb.dingdong.domain.user.repository.projection.HomeLocationProjection;
+import com.ddbb.dingdong.domain.user.repository.projection.HomeStationProjection;
 import com.ddbb.dingdong.domain.user.repository.projection.SchoolIDProjection;
 import com.ddbb.dingdong.domain.user.repository.projection.UserStaticOnly;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,9 @@ public interface UserQueryRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.school.id as schoolId FROM User u WHERE u.id = :userId")
     Optional<SchoolIDProjection> findSchoolIDByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT u.school.id as schoolId, h.stationLatitude as stationLatitude, h.stationLongitude as stationLongitude " +
+            "FROM User u JOIN Home h ON h.user.id = u.id " +
+            "WHERE u.id = :userId")
+    Optional<HomeStationProjection> findHomeStationLocationWithSchoolId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/projection/HomeStationProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/projection/HomeStationProjection.java
@@ -1,0 +1,7 @@
+package com.ddbb.dingdong.domain.user.repository.projection;
+
+public interface HomeStationProjection {
+    Double getStationLongitude();
+    Double getStationLatitude();
+    Long getSchoolId();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/bus/BusController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/bus/BusController.java
@@ -1,12 +1,14 @@
 package com.ddbb.dingdong.presentation.endpoint.bus;
 
 import com.ddbb.dingdong.application.exception.APIException;
+import com.ddbb.dingdong.application.usecase.bus.GetAvailableBusLine;
 import com.ddbb.dingdong.application.usecase.bus.GetBusSchedulesUseCase;
 import com.ddbb.dingdong.domain.common.exception.DomainException;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.infrastructure.auth.AuthUser;
 import com.ddbb.dingdong.infrastructure.auth.annotation.LoginUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,11 +16,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.ZonedDateTime;
+
 @RestController
 @RequestMapping("/api/bus")
 @RequiredArgsConstructor
 public class BusController {
     private final GetBusSchedulesUseCase getBusSchedulesUseCase;
+    private final GetAvailableBusLine getAvailableBusLine;
 
     @GetMapping("/schedule/time")
     public ResponseEntity<GetBusSchedulesUseCase.Response> getBusSchedules(
@@ -28,6 +33,21 @@ public class BusController {
         try {
             GetBusSchedulesUseCase.Param param = new GetBusSchedulesUseCase.Param(authUser.id(), direction);
             return ResponseEntity.ok(getBusSchedulesUseCase.execute(param));
+        } catch (DomainException e) {
+            throw new APIException(e, HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @GetMapping("/available")
+    public ResponseEntity<GetAvailableBusLine.Response> getBusSchedules(
+            @LoginUser AuthUser authUser,
+            @RequestParam("direction") Direction direction,
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) @RequestParam("time") ZonedDateTime time
+    ) {
+        try {
+            GetAvailableBusLine.Param param = new GetAvailableBusLine.Param(authUser.id(), time.toLocalDateTime(), direction);
+            GetAvailableBusLine.Response result = getAvailableBusLine.execute(param);
+            return ResponseEntity.ok(result);
         } catch (DomainException e) {
             throw new APIException(e, HttpStatus.NOT_FOUND);
         }


### PR DESCRIPTION
## 관련 이슈
- #133

## 📝 상세 내용
- 방향과 시간을 입력으로 하여, "함께 타기" 가능한 정류장 정보들을 조회하는 API를 구현합니다.
    - 정류장 정보에는 버스 이름, 정류장 위치, 정류장 이름, 해당 노선에 예약한 인원 수, 버스 가용 인원 수가 포함됩니다.
- 사용자가 지정한 탑승지 위치를 기준 1km 이내에 있고, 같은 노선의 정류장이 여러 개 있다면 제일 가까운 하나의 정류장만 조회합니다.
- 조회되는 정류장은 그 시간 기준 아직 출발하지 않은 노선의 정류장만 조회합니다.
- 노선에 예약된 인원 수는 ticket 컬럼의 개수 기준으로 가져옵니다. (데드락 회피 및 동시성 성능 확보 목적) 
