### PR TITLE
[BE] 알림 기능 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/CheckUnreadNotificationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/CheckUnreadNotificationUseCase.java
@@ -7,12 +7,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class CheckUnreadNotificationUseCase implements UseCase<CheckUnreadNotificationUseCase.Param, CheckUnreadNotificationUseCase.Result> {
     private final NotificationManagement notificationManagement;
 
+    @Transactional
     @Override
     public Result execute(Param param) {
         Long userId = param.getUserId();

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/CheckUnreadNotificationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/CheckUnreadNotificationUseCase.java
@@ -1,0 +1,35 @@
+package com.ddbb.dingdong.application.usecase.notification;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.notification.service.NotificationManagement;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CheckUnreadNotificationUseCase implements UseCase<CheckUnreadNotificationUseCase.Param, CheckUnreadNotificationUseCase.Result> {
+    private final NotificationManagement notificationManagement;
+
+    @Override
+    public Result execute(Param param) {
+        Long userId = param.getUserId();
+        boolean hasUnreadNotifications = notificationManagement.hasUnreadNotifications(userId);
+
+        return new Result(hasUnreadNotifications);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private Long userId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Result {
+        boolean hasUnreadNotifications;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/GetNotificationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/GetNotificationsUseCase.java
@@ -41,6 +41,7 @@ public class GetNotificationsUseCase implements UseCase<GetNotificationsUseCase.
                 new Result.NotificationInfo(
                         projection.getType(),
                         projection.getTimeStamp(),
+                        projection.getIsRead(),
                         new Result.ReservationInfo(
                                 projection.getReservationId(),
                                 projection.startStationName(),
@@ -70,6 +71,7 @@ public class GetNotificationsUseCase implements UseCase<GetNotificationsUseCase.
         public static class NotificationInfo {
             private NotificationType type;
             private LocalDateTime timeStamp;
+            private boolean isRead;
             private ReservationInfo reservationInfo;
         }
 

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/GetNotificationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/GetNotificationsUseCase.java
@@ -1,0 +1,87 @@
+package com.ddbb.dingdong.application.usecase.notification;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.notification.entity.vo.NotificationType;
+import com.ddbb.dingdong.domain.notification.repository.NotificationQueryRepository;
+import com.ddbb.dingdong.domain.notification.repository.projection.NotificationProjection;
+import com.ddbb.dingdong.domain.notification.service.NotificationManagement;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class GetNotificationsUseCase implements UseCase<GetNotificationsUseCase.Param, GetNotificationsUseCase.Result> {
+    private final NotificationQueryRepository notificationQueryRepository;
+    private final NotificationManagement notificationManagement;
+
+    @Transactional
+    @Override
+    public Result execute(Param param) {
+        Long userId = param.getUserId();
+        Pageable pageable = param.getPageable();
+        Page<Result.NotificationInfo> notificationInfos = getNotifications(userId, pageable);
+        notificationManagement.readAllNotifications(userId);
+
+        return new Result(notificationInfos);
+    }
+
+    private Page<Result.NotificationInfo> getNotifications(Long userId, Pageable pageable) {
+        Page<NotificationProjection> projections = notificationQueryRepository.queryUserNotifications(userId, pageable);
+
+        return projections.map(projection ->
+                new Result.NotificationInfo(
+                        projection.getType(),
+                        projection.getTimeStamp(),
+                        new Result.ReservationInfo(
+                                projection.getReservationId(),
+                                projection.startStationName(),
+                                projection.endStationName(),
+                                projection.getStartDate(),
+                                projection.getExpectedStartTime(),
+                                projection.getExpectedEndTime()
+                        )
+                )
+        );
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private Long userId;
+        private Pageable pageable;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Result {
+        private Page<NotificationInfo> notifications;
+
+        @Getter
+        @AllArgsConstructor
+        public static class NotificationInfo {
+            private NotificationType type;
+            private LocalDateTime timeStamp;
+            private ReservationInfo reservationInfo;
+        }
+
+        @Getter
+        @AllArgsConstructor
+        public static class ReservationInfo {
+            private Long reservationId;
+            private String startStationName;
+            private String endStationName;
+            private LocalDate startDate;
+            private LocalDateTime expectedStartTime;
+            private LocalDateTime expectedEndTime;
+        }
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeGeneralReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeGeneralReservationUseCase.java
@@ -83,6 +83,7 @@ public class MakeGeneralReservationUseCase implements UseCase<MakeGeneralReserva
             location.setReservationId(reservationId);
             location.setLatitude(home.getStationLatitude());
             location.setLongitude(home.getStationLongitude());
+            location.setStationName(home.getStationName());
             clusteringService.saveLocation(location);
         }
     }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/clustering/entity/Location.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/clustering/entity/Location.java
@@ -22,6 +22,9 @@ public class Location {
     private Long reservationId;
 
     @Column(nullable = false)
+    private String stationName;
+
+    @Column(nullable = false)
     private Double longitude;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/entity/Notification.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/entity/Notification.java
@@ -1,15 +1,17 @@
-package com.ddbb.dingdong.domain.notification;
+package com.ddbb.dingdong.domain.notification.entity;
 
-import com.ddbb.dingdong.domain.reservation.entity.vo.NotificationType;
+import com.ddbb.dingdong.domain.notification.entity.vo.NotificationType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Notification {
@@ -22,7 +24,7 @@ public class Notification {
     private NotificationType type;
 
     @Column(nullable = false)
-    private Boolean isRead;
+    private Boolean isRead = false;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
@@ -32,4 +34,8 @@ public class Notification {
 
     @Column(nullable = false)
     private Long reservationId;
+
+    public void read(){
+        this.isRead = true;
+    }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/entity/vo/NotificationType.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/entity/vo/NotificationType.java
@@ -1,8 +1,8 @@
-package com.ddbb.dingdong.domain.reservation.entity.vo;
+package com.ddbb.dingdong.domain.notification.entity.vo;
 
 public enum NotificationType {
     ALLOCATION_SUCCESS,
     ALLOCATION_FAILED,
-    BOARDING_REMINDER,
+    BUS_START,
     ;
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/NotificationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/NotificationQueryRepository.java
@@ -1,0 +1,44 @@
+package com.ddbb.dingdong.domain.notification.repository;
+
+import com.ddbb.dingdong.domain.notification.entity.Notification;
+import com.ddbb.dingdong.domain.notification.repository.projection.NotificationProjection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationQueryRepository extends JpaRepository<Notification, Long> {
+    @Query("""
+    SELECT
+        n.createdAt AS timeStamp,
+        n.type AS type,
+        n.isRead AS isRead,
+        r.id AS reservationId,
+        CASE
+            WHEN r.direction = 'TO_SCHOOL' THEN l.stationName
+            ELSE u.school.name
+        END AS startStationName,
+        CASE
+            WHEN r.direction = 'TO_SCHOOL' THEN u.school.name
+            ELSE l.stationName
+        END AS endStationName,
+        r.startDate AS startDate,
+        CASE
+            WHEN r.direction = 'TO_SCHOOL' THEN bs.expectedArrivalTime
+            ELSE r.departureTime
+        END AS expectedStartTime,
+        CASE
+            WHEN r.direction = 'TO_SCHOOL' THEN r.arrivalTime
+            ELSE bs.expectedArrivalTime
+        END AS expectedEndTime
+    FROM Notification n
+    JOIN Reservation r ON n.reservationId = r.id
+    JOIN Location l ON l.reservationId = r.id
+    JOIN User u ON n.userId = u.id
+    LEFT JOIN BusStop bs ON bs.locationId = l.id
+    WHERE n.userId = :userId
+    ORDER BY n.createdAt DESC
+    """)
+    Page<NotificationProjection> queryUserNotifications(@Param("userId") Long userId, Pageable pageable);
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.ddbb.dingdong.domain.notification.repository;
+
+import com.ddbb.dingdong.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByUserIdAndIsReadFalse(Long userId);
+
+    boolean existsByUserIdAndIsReadFalse(Long userId);
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/projection/NotificationProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/projection/NotificationProjection.java
@@ -1,0 +1,18 @@
+package com.ddbb.dingdong.domain.notification.repository.projection;
+
+import com.ddbb.dingdong.domain.notification.entity.vo.NotificationType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public interface NotificationProjection {
+    NotificationType getType();
+    Boolean getIsRead();
+    Long getReservationId();
+    String startStationName();
+    String endStationName();
+    LocalDateTime getTimeStamp();
+    LocalDate getStartDate();
+    LocalDateTime getExpectedStartTime();
+    LocalDateTime getExpectedEndTime();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
@@ -46,6 +46,7 @@ public class NotificationEventListener {
             while (retryTimes < 3) {
                 try {
                     socket.sendMessage(new TextMessage(ALARM_SOCKET_MSG));
+                    break;
                 } catch (IOException e) {
                     retryTimes++;
                 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
@@ -1,0 +1,56 @@
+package com.ddbb.dingdong.domain.notification.service;
+
+import com.ddbb.dingdong.domain.notification.entity.vo.NotificationType;
+import com.ddbb.dingdong.domain.reservation.service.event.AllocationFailedEvent;
+import com.ddbb.dingdong.domain.reservation.service.event.AllocationSuccessEvent;
+import com.ddbb.dingdong.infrastructure.webSocket.repository.SocketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+    private final NotificationManagement notificationManagement;
+    private final SocketRepository socketRepository;
+    private static final String ALARM_SOCKET_MSG = "alarm";
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @EventListener
+    protected void sendAllocationSuccessNotification(AllocationSuccessEvent event) {
+        notificationManagement.sendNotification(NotificationType.ALLOCATION_SUCCESS, event.getUserId(), event.getReservationId());
+        sendSocketMessage(event.getUserId());
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @EventListener
+    protected void sendAllocationFailNotification(AllocationFailedEvent event) {
+        notificationManagement.sendNotification(NotificationType.ALLOCATION_FAILED, event.getUserId(), event.getReservationId());
+        sendSocketMessage(event.getUserId());
+    }
+
+    private void sendSocketMessage(Long userId) {
+        WebSocketSession socket = socketRepository.get(userId);
+
+        if(socket != null && socket.isOpen()) {
+            int retryTimes = 0;
+            while (retryTimes < 3) {
+                try {
+                    socket.sendMessage(new TextMessage(ALARM_SOCKET_MSG));
+                } catch (IOException e) {
+                    retryTimes++;
+                }
+            }
+        }
+    }
+
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationManagement.java
@@ -1,0 +1,35 @@
+package com.ddbb.dingdong.domain.notification.service;
+
+import com.ddbb.dingdong.domain.notification.entity.Notification;
+import com.ddbb.dingdong.domain.notification.entity.vo.NotificationType;
+import com.ddbb.dingdong.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationManagement {
+    private final NotificationRepository notificationRepository;
+
+    public boolean hasUnreadNotifications(Long userId) {
+        return notificationRepository.existsByUserIdAndIsReadFalse(userId);
+    }
+
+    public void readAllNotifications(Long userId) {
+        List<Notification> notifications = notificationRepository.findAllByUserIdAndIsReadFalse(userId);
+        notifications.forEach(Notification::read);
+
+        notificationRepository.saveAll(notifications);
+    }
+
+    public void sendNotification(NotificationType type, Long userId, Long reservationId) {
+        Notification notification = new Notification();
+        notification.setUserId(userId);
+        notification.setReservationId(reservationId);
+        notification.setType(type);
+
+        notificationRepository.save(notification);
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/error/NotificationErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/error/NotificationErrors.java
@@ -1,0 +1,18 @@
+package com.ddbb.dingdong.domain.notification.service.error;
+
+import com.ddbb.dingdong.domain.common.exception.ErrorInfo;
+
+public enum NotificationErrors implements ErrorInfo {
+    ;
+
+    private final String desc;
+
+    NotificationErrors(String desc) {
+        this.desc = desc;
+    }
+
+    @Override
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/payment/service/PaymentManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/payment/service/PaymentManagement.java
@@ -31,7 +31,7 @@ public class PaymentManagement {
     @EventListener
     public void refund(AllocationFailedEvent event) {
         Long userId = event.getUserId();
-        Long reservationId = event.getReservationInfo().getReservationId();
+        Long reservationId = event.getReservationId();
         Wallet wallet = walletRepository.findWalletByUserIdForUpdate(userId)
                 .orElseThrow(PaymentErrors.WALLET_NOT_FOUND::toException);
         wallet.refund(PRICE, reservationId);

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationManagement.java
@@ -52,7 +52,7 @@ public class ReservationManagement {
         reservation.allocate(ticket);
         reservationRepository.save(reservation);
 
-        eventPublisher.publishEvent(new AllocationSuccessEvent(reservation.getId()));
+        eventPublisher.publishEvent(new AllocationSuccessEvent(reservation.getId(), reservation.getUserId()));
     }
 
 
@@ -62,16 +62,7 @@ public class ReservationManagement {
         reservation.fail();
         reservationRepository.save(reservation);
 
-        eventPublisher.publishEvent(new AllocationFailedEvent(
-                reservation.getUserId(),
-                new AllocationFailedEvent.ReservationInfo(
-                        reservationId,
-                        reservation.getDirection(),
-                        reservation.getDirection().equals(Direction.TO_HOME) ? reservation.getDepartureTime() : reservation.getArrivalTime(),
-                        reservation.getStartDate()
-                ),
-                LocalDateTime.now()
-        ));
+        eventPublisher.publishEvent(new AllocationFailedEvent(reservation.getId(), reservation.getUserId()));
     }
 
     private void validateDateOfGeneralReservation(Reservation reservation) {

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/event/AllocationFailedEvent.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/event/AllocationFailedEvent.java
@@ -1,25 +1,11 @@
 package com.ddbb.dingdong.domain.reservation.service.event;
 
-import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 public class AllocationFailedEvent {
+    private Long reservationId;
     private Long userId;
-    private ReservationInfo reservationInfo;
-    private LocalDateTime timestamp;
-
-    @Getter
-    @AllArgsConstructor
-    public static class ReservationInfo {
-        private Long reservationId;
-        private Direction direction;
-        private LocalDateTime dingdongTime;
-        private LocalDate startDate;
-    }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/event/AllocationSuccessEvent.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/event/AllocationSuccessEvent.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AllocationSuccessEvent {
     private Long reservationId;
+    private Long userId;
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/entity/BusSchedule.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/entity/BusSchedule.java
@@ -37,7 +37,7 @@ public class BusSchedule {
     @Column(nullable = false)
     private Long schoolId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "bus_id")
     private Bus bus;
 

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/notification/NotificationController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/notification/NotificationController.java
@@ -1,0 +1,60 @@
+package com.ddbb.dingdong.presentation.endpoint.notification;
+
+import com.ddbb.dingdong.application.exception.APIException;
+import com.ddbb.dingdong.application.usecase.notification.CheckUnreadNotificationUseCase;
+import com.ddbb.dingdong.application.usecase.notification.GetNotificationsUseCase;
+import com.ddbb.dingdong.domain.common.exception.DomainException;
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.annotation.LoginUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/notifications")
+public class NotificationController {
+    private final GetNotificationsUseCase getNotificationsUseCase;
+    private final CheckUnreadNotificationUseCase checkUnreadNotificationUseCase;
+
+    @GetMapping
+    public ResponseEntity<GetNotificationsUseCase.Result> getUserNotifications(
+            @LoginUser AuthUser user,
+            @RequestParam("page") int page,
+            @RequestParam("pageSize") int pageSize
+    ) {
+        Long userid = user.id();
+        Pageable pageable = PageRequest.of(page, pageSize);
+        GetNotificationsUseCase.Param param = new GetNotificationsUseCase.Param(userid, pageable);
+        GetNotificationsUseCase.Result result;
+        try {
+            result = getNotificationsUseCase.execute(param);
+        } catch (DomainException ex) {
+            throw new APIException(ex, HttpStatus.BAD_REQUEST);
+        }
+
+        return ResponseEntity.ok().body(result);
+    }
+
+    @GetMapping("/check-unread")
+    public ResponseEntity<CheckUnreadNotificationUseCase.Result> getUserNotifications(
+            @LoginUser AuthUser user
+    ) {
+        Long userid = user.id();
+        CheckUnreadNotificationUseCase.Param param = new CheckUnreadNotificationUseCase.Param(userid);
+        CheckUnreadNotificationUseCase.Result result;
+        try {
+            result = checkUnreadNotificationUseCase.execute(param);
+        } catch (DomainException ex) {
+            throw new APIException(ex, HttpStatus.BAD_REQUEST);
+        }
+
+        return ResponseEntity.ok().body(result);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #154 

## 📝 상세 내용
- 예매 실패, 예매 성공시 발행한 event를 수신하고있는 event listener를 구현하여, 알림을 저장하는 기능을 구현했습니다.
(따로 api를 호출하는것이아닌, 예매 실패/성공 시 자동적으로 알림이 저장됩니다)
알림이 저장되고나서, socket.sendMessage를 통해 "alarm"이라는 텍스트메세지를 전달합니다.
- 안읽은 메세지가 있는지 boolean으로 반환할수 있는 HTTP API를 구현하였습니다.
- 알림 내역조회를 페이지네이션으로 반환하는 API를 구현하였습니다. 해당 API를 호출하면, 그 당시 있던 알림은 모두 read처리가 되게 됩니다.

## 전달 사항
- 버스 출발에 대한 알림 listener를 구현하지 않았습니다.
- @ji-woong-song 님이 버스 출발을 구현해주신 이후에 추가 할 예정입니다.
