### PR TITLE
[BE] 예매 조회시 BusScheduleId도 조회하도록 변경

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
@@ -46,6 +46,7 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
                     Result.ReservationInfo.OperationInfo operationInfo = null;
                     if(ReservationStatus.ALLOCATED.name().equals(r.getReservationStatus())) {
                         operationInfo = new Result.ReservationInfo.OperationInfo(
+                                r.getBusScheduleId(),
                                 r.getBusStatus(),
                                 r.getBusName(),
                                 r.getBusStopArrivalTime(),
@@ -96,6 +97,7 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
             @Getter
             @AllArgsConstructor
             public static class OperationInfo {
+                private Long busScheduleId;
                 private String busStatus;
                 private String busName;
                 private LocalDateTime busStopArrivalTime;

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -16,6 +16,7 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
                r.direction AS direction,
                r.arrivalTime AS expectedArrivalTime,
                r.status AS reservationStatus,
+               bs_arrival.id AS busScheduleId,
                b.name AS busName,
                bs_arrival.status AS busStatus,
                bs.roadNameAddress AS busStopRoadNameAddress,

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/projection/UserReservationProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/projection/UserReservationProjection.java
@@ -11,6 +11,7 @@ public interface UserReservationProjection {
     String getDirection();
     LocalDateTime getExpectedArrivalTime();
     String getReservationStatus();
+    Long getBusScheduleId();
     String getBusStatus();
     String getBusName();
     LocalDateTime getBusStopArrivalTime();


### PR DESCRIPTION
### 관련 이슈
- #162 

### 전달 사항
- 조회 결과에 중복된 필드가 여러개 반환되는 버그가있어서 수정할 예정입니다.