### PR TITLE
[BE] 예매 내역 조회 중복 튜플 반환했던 버그 해결

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
@@ -2,9 +2,11 @@ package com.ddbb.dingdong.application.usecase.reservation;
 
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationStatus;
 import com.ddbb.dingdong.domain.reservation.repository.ReservationQueryRepository;
 import com.ddbb.dingdong.domain.reservation.repository.projection.UserReservationProjection;
+import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
 import com.ddbb.dingdong.presentation.endpoint.reservation.exchanges.enums.ReservationCategory;
 import com.ddbb.dingdong.presentation.endpoint.reservation.exchanges.enums.SortType;
 import lombok.AllArgsConstructor;
@@ -30,10 +32,10 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
     public Result execute(Param param) {
         int category = switch (param.category) {
             case ALL -> 0;
-            case ALLOCATION_SUCCESS -> 1;
-            case ALLOCATION_PENDING -> 2;
-            case ALLOCATION_FAILED -> 3;
-            case OPERATION_FINISHED -> 4;
+            case ALLOCATED -> 1;
+            case PENDING -> 2;
+            case FAIL_ALLOCATED -> 3;
+            case ENDED -> 4;
             case CANCELED -> 5;
         };
         int sort = switch (param.sort) {
@@ -44,7 +46,7 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
         List<Result.ReservationInfo> reservationInfos = result.stream()
                 .map(r -> {
                     Result.ReservationInfo.OperationInfo operationInfo = null;
-                    if(ReservationStatus.ALLOCATED.name().equals(r.getReservationStatus())) {
+                    if(ReservationStatus.ALLOCATED.equals(r.getReservationStatus())) {
                         operationInfo = new Result.ReservationInfo.OperationInfo(
                                 r.getBusScheduleId(),
                                 r.getBusStatus(),
@@ -89,16 +91,16 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
             private Long reservationId;
             private LocalDate startDate;
             private String busStopName;
-            private String direction;
+            private Direction direction;
             private LocalDateTime expectedArrivalTime;
-            private String reservationStatus;
+            private ReservationStatus reservationStatus;
             private OperationInfo operationInfo;
 
             @Getter
             @AllArgsConstructor
             public static class OperationInfo {
                 private Long busScheduleId;
-                private String busStatus;
+                private OperationStatus busStatus;
                 private String busName;
                 private LocalDateTime busStopArrivalTime;
                 private Integer totalMinutes;

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReservationQueryRepository extends JpaRepository<Reservation, Long> {
     @Query("""
-        SELECT u.home.stationName AS userHomeStationName,
+        SELECT DISTINCT l.stationName AS userHomeStationName,
                r.id AS reservationId,
                r.startDate AS startDate,
                r.direction AS direction,
@@ -28,7 +28,7 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
         LEFT JOIN BusSchedule bs_arrival ON bs_arrival.id = t.busScheduleId
         LEFT JOIN Bus b ON bs_arrival.bus.id = b.id
         LEFT JOIN Path p ON p.busSchedule.id = bs_arrival.id
-        LEFT JOIN User u ON r.userId = :userId
+        LEFT JOIN Location l ON l.reservationId = r.id
         WHERE r.userId = :userId
             AND (
                 (:category = 0)
@@ -37,7 +37,7 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
                 OR
                 (:category = 2 AND CAST(r.status AS STRING) = 'PENDING')
                 OR
-                (:category = 3 AND CAST(r.status AS STRING) = 'NOT_ALLOCATED')
+                (:category = 3 AND CAST(r.status AS STRING) = 'FAIL_ALLOCATED')
                 OR
                 (:category = 4 AND CAST(bs_arrival.status AS STRING) = 'ENDED')
                 OR

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/projection/UserReservationProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/projection/UserReservationProjection.java
@@ -1,5 +1,9 @@
 package com.ddbb.dingdong.domain.reservation.repository.projection;
 
+import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationStatus;
+import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -8,11 +12,11 @@ public interface UserReservationProjection {
     LocalDate getStartDate();
     String getBusStopRoadNameAddress();
     String getUserHomeStationName();
-    String getDirection();
+    Direction getDirection();
     LocalDateTime getExpectedArrivalTime();
-    String getReservationStatus();
+    ReservationStatus getReservationStatus();
     Long getBusScheduleId();
-    String getBusStatus();
+    OperationStatus getBusStatus();
     String getBusName();
     LocalDateTime getBusStopArrivalTime();
     Integer getTotalMinutes();

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/exchanges/enums/ReservationCategory.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/exchanges/enums/ReservationCategory.java
@@ -2,9 +2,9 @@ package com.ddbb.dingdong.presentation.endpoint.reservation.exchanges.enums;
 
 public enum ReservationCategory {
     ALL,
-    ALLOCATION_SUCCESS,
-    ALLOCATION_PENDING,
-    ALLOCATION_FAILED,
-    OPERATION_FINISHED,
+    ALLOCATED,
+    PENDING,
+    FAIL_ALLOCATED,
+    ENDED,
     CANCELED,
 }


### PR DESCRIPTION
## 관련 이슈
- #167 

## 해결 방법

- JPQL의 SELECT절에 DISTINCT 키워드를 붙여서 중복 튜플 제거,
- user.home.stationName으로 찾아오는것이아닌, location.stationName으로 찾아오도록 최적화

## 발견한 또다른 버그

- type이 TO_SCHOOL이면 예상 도착시간이므로 arrival_time을 가져오고, type이 TO_HOME일때는 예상 출발시간이므로 departure_time을 가져와야하는데, 이런 분기 처리가 안되어있음을 확인했습니다.