### PR TITLE
[BE] tmap api이용한 경유지 최적화 코드 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
@@ -54,8 +54,7 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
                                 r.getBusScheduleId(),
                                 r.getBusStatus(),
                                 r.getBusName(),
-                                r.getBusStopArrivalTime(),
-                                r.getTotalMinutes()
+                                r.getBusStopArrivalTime()
                         );
                         expectedDepartureTime = r.getRealDepartureTime();
                         expectedArrivalTime = r.getRealArrivalTime();
@@ -110,7 +109,6 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
                 private OperationStatus busStatus;
                 private String busName;
                 private LocalDateTime busStopArrivalTime;
-                private Integer totalMinutes;
             }
         }
     }

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/routing/CreateRouteUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/routing/CreateRouteUseCase.java
@@ -49,8 +49,8 @@ public class CreateRouteUseCase implements UseCase<CreateRouteUseCase.Param, Voi
         Direction direction = anyReservation.getDirection();
         School school = userManagement.load(anyReservation.getUserId()).getSchool();
         List<Location> locations = clusteringService.findByClusterLabel(clusterLabel);
-        Path path = busRouteCreationService.routeOptimization(locations, school, direction);
-        LocalDateTime dingdongTime = direction.equals(Direction.TO_HOME) ? anyReservation.getDepartureTime() : anyReservation.getArrivalTime();
+        LocalDateTime dingdongTime = direction.equals(Direction.TO_SCHOOL) ? anyReservation.getArrivalTime() : anyReservation.getDepartureTime();
+        Path path = busRouteCreationService.routeOptimization(locations, school, direction, dingdongTime);
         BusSchedule busSchedule = busScheduleManagement.allocateBusSchedule(
                 path,
                 school.getId(),

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -23,14 +23,12 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
                b.name AS busName,
                bs_arrival.status AS busStatus,
                bs.roadNameAddress AS busStopRoadNameAddress,
-               bs.expectedArrivalTime AS busStopArrivalTime,
-               p.totalMinutes AS totalMinutes
+               bs.expectedArrivalTime AS busStopArrivalTime
         FROM Reservation r
         LEFT JOIN Ticket t ON r.id = t.reservation.id
         LEFT JOIN BusStop bs ON t.busStopId = bs.id
         LEFT JOIN BusSchedule bs_arrival ON bs_arrival.id = t.busScheduleId
         LEFT JOIN Bus b ON bs_arrival.bus.id = b.id
-        LEFT JOIN Path p ON p.busSchedule.id = bs_arrival.id
         LEFT JOIN Location l ON l.reservationId = r.id
         WHERE r.userId = :userId
             AND (

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/projection/UserReservationProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/projection/UserReservationProjection.java
@@ -22,5 +22,4 @@ public interface UserReservationProjection {
     OperationStatus getBusStatus();
     String getBusName();
     LocalDateTime getBusStopArrivalTime();
-    Integer getTotalMinutes();
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/entity/Path.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/entity/Path.java
@@ -19,10 +19,10 @@ public class Path {
     private Long id;
 
     @Column(nullable = false)
-    private Double totalDistance;
+    private Double totalMeter;
 
     @Column(nullable = false)
-    private Integer totalMinutes;
+    private Integer totalSeconds;
 
     @OneToMany(mappedBy = "path", cascade = CascadeType.PERSIST)
     private List<Line> lines;

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/routing/BusRouteCreationService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/routing/BusRouteCreationService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -22,14 +23,14 @@ public class BusRouteCreationService {
     private final TmapRouteOptimizationApiClient apiClient;
     private final TmapRouteOptimizationDTOConverter routeOptimizationDTOConverter;
 
-    public Path routeOptimization(List<Location> locations, School school, Direction direction) {
+    public Path routeOptimization(List<Location> locations, School school, Direction direction, LocalDateTime dingdongTime) {
         RequestRouteOptimizationDTO request;
         ResponseRouteOptimizationDTO response;
 
         request = generateRequests(locations, school, direction);
         response = apiClient.getRouteOptimization(request);
 
-        return routeOptimizationDTOConverter.toPath(response);
+        return routeOptimizationDTOConverter.toPath(response, dingdongTime, direction);
     }
 
     private RequestRouteOptimizationDTO generateRequests(List<Location> locations, School school, Direction direction) {


### PR DESCRIPTION
### 관련 이슈
- #178 


### 구현 항목

- [x] 중복된 위도/경도를 경유지로 입력했을때, 버그가 발생한 문제 해결 (중복된 경유지가 나올때 count를 1씩 증가시키고, 다음 lineString에서 count를 1씩 마이너스 시키면서 중복 bus stop을 생성하도록 로직을 구현하였습니다)
- [x] 딩동시간을 기준으로, 각각의 버스 정류장에 도착하는 예상 시간을 역산하여 반영하였습니다.
- [x] 등교와 하교를 분기처리 하였습니다   