### PR TITLE
[BE] 긴급 수정 Projection 코드버그 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/GetNotificationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/GetNotificationsUseCase.java
@@ -44,8 +44,8 @@ public class GetNotificationsUseCase implements UseCase<GetNotificationsUseCase.
                         projection.getIsRead(),
                         new Result.ReservationInfo(
                                 projection.getReservationId(),
-                                projection.startStationName(),
-                                projection.endStationName(),
+                                projection.getStartStationName(),
+                                projection.getEndStationName(),
                                 projection.getStartDate(),
                                 projection.getExpectedStartTime(),
                                 projection.getExpectedEndTime()

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/projection/NotificationProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/projection/NotificationProjection.java
@@ -9,8 +9,8 @@ public interface NotificationProjection {
     NotificationType getType();
     Boolean getIsRead();
     Long getReservationId();
-    String startStationName();
-    String endStationName();
+    String getStartStationName();
+    String getEndStationName();
     LocalDateTime getTimeStamp();
     LocalDate getStartDate();
     LocalDateTime getExpectedStartTime();


### PR DESCRIPTION
### 버그 내용
JPA Projection에서는 get~~() 처럼 get으로 시작해야하는데,
실수로 startStationName()으로 get을 빼먹어 버그가 발생하였고 이를 수정하였음.