### PR TITLE
[BE] 30분마다 환불 실패한 내역 찾아 retry하는 scheduler 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/domain/payment/repository/WalletProjectionRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/payment/repository/WalletProjectionRepository.java
@@ -1,0 +1,24 @@
+package com.ddbb.dingdong.domain.payment.repository;
+
+import com.ddbb.dingdong.domain.payment.entity.Wallet;
+import com.ddbb.dingdong.domain.payment.repository.projection.FailedRefundProjection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface WalletProjectionRepository extends JpaRepository<Wallet, Long> {
+    @Query("""
+        SELECT r.id AS reservationId, u.id AS userId
+        FROM Reservation r
+        JOIN User u ON r.userId = u.id
+        JOIN Wallet w ON w.userId = u.id
+        LEFT JOIN DingdongMoneyUsageHistory history
+            ON w.id = history.wallet.id
+            AND history.refundedReservationId = r.id
+            AND history.type = 'REFUND'
+        WHERE r.status = 'FAIL_ALLOCATED'
+        AND history.id IS NULL
+    """)
+    List<FailedRefundProjection> queryAllFailedRefund();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/payment/repository/projection/FailedRefundProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/payment/repository/projection/FailedRefundProjection.java
@@ -1,0 +1,6 @@
+package com.ddbb.dingdong.domain.payment.repository.projection;
+
+public interface FailedRefundProjection {
+    Long getUserId();
+    Long getReservationId();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/payment/service/RetryScheduler.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/payment/service/RetryScheduler.java
@@ -1,0 +1,38 @@
+package com.ddbb.dingdong.domain.payment.service;
+
+import com.ddbb.dingdong.domain.payment.repository.WalletProjectionRepository;
+import com.ddbb.dingdong.domain.payment.repository.projection.FailedRefundProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Component
+@RequiredArgsConstructor
+public class RetryScheduler {
+    private final WalletProjectionRepository walletProjectionRepository;
+    private static final int THREAD_SIZE = 3;
+    private final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_SIZE);
+    private final PaymentManagement paymentManagement;
+
+    @Scheduled(fixedRate = 1800000, initialDelay = 10000)
+    public void retryFailedRefund() {
+        List<FailedRefundProjection> projections = walletProjectionRepository.queryAllFailedRefund();
+
+        int batchSize = (int) Math.ceil((double) projections.size() / THREAD_SIZE);
+
+        for (int i = 0; i < projections.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, projections.size());
+            List<FailedRefundProjection> batch = projections.subList(i, end);
+
+            executorService.submit(() -> {
+                for (FailedRefundProjection projection : batch) {
+                    paymentManagement.refund(projection.getUserId(), projection.getReservationId());
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
### 구현 내용
- reservation status가 FAIL_ALLOCATED 인데, usageHistory에 해당 reservation id가 REFUND인것이 없는 것을 환불이 실패한 것으로 간주합니다.
-  `@Schedule`을 사용해 30분마다 해당 list를 projection하여 환불 실패된 내역을 전부 찾아옵니다.
- 내역을 3분할하여, 3개의 쓰레드에서 병렬처리를 시키도록 하였습니다.