### PR TITLE
[BE] 한 토큰으로 중복 결제하는 문제 해결

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeGeneralReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeGeneralReservationUseCase.java
@@ -45,6 +45,7 @@ public class MakeGeneralReservationUseCase implements UseCase<MakeGeneralReserva
         checkHasDuplicatedReservation(param.reservationInfo.userId, param.reservationInfo.reservationDates);
         reserve(param);
         pay(param);
+        saveToken(param);
 
         return null;
     }
@@ -93,6 +94,10 @@ public class MakeGeneralReservationUseCase implements UseCase<MakeGeneralReserva
         Long userId = param.getReservationInfo().userId;
         int quantity = param.getReservationInfo().getReservationDates().size();
         paymentManagement.pay(userId, quantity);
+    }
+
+    private void saveToken(Param param) {
+        tokenManager.saveToken(param.token);
     }
 
     @Getter

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
@@ -43,8 +43,13 @@ public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReser
         checkHasDuplicatedReservation(param.reservationInfo.userId, hopeTime);
         reserve(param);
         pay(param);
+        saveToken(param);
 
         return null;
+    }
+
+    private void saveToken(Param param) {
+        tokenManager.saveToken(param.token);
     }
 
     private void checkHasDuplicatedReservation(Long userId, LocalDateTime hopeTime) {

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/Token.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/Token.java
@@ -1,0 +1,21 @@
+package com.ddbb.dingdong.infrastructure.auth.encrypt;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Token {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/TokenErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/TokenErrors.java
@@ -6,7 +6,8 @@ public enum TokenErrors implements ErrorInfo {
     FAILED_TO_GENERATE("토큰 생성에 실패하였습니다"),
     INCORRECT_SIGNATURE("토큰 서명이 일치하지 않습니다."),
     EXPIRED("토큰 유효기간이 만료되었습니다."),
-    INVALID("토큰 형식이 올바르지 않습니다.")
+    INVALID("토큰 형식이 올바르지 않습니다."),
+    ALREADY_USED("이미 사용된 토큰입니다"),
     ;
 
     private final String desc;

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/TokenManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/TokenManager.java
@@ -18,6 +18,7 @@ public class TokenManager {
     private static final String DELIMITER = "$";
     private final SHA512Encoder sha512Encoder;
     private final AESEncoder aesEncoder;
+    private final TokenRepository tokenRepository;
 
     public String generateToken(Object target) {
         String data;
@@ -34,6 +35,10 @@ public class TokenManager {
     }
 
     public boolean validateToken(String token, Object target)  {
+        if(tokenRepository.existsByToken(token)) {
+            throw TokenErrors.ALREADY_USED.toException();
+        }
+
         String data;
         try {
             ObjectMapper objectMapper = new ObjectMapper();
@@ -60,7 +65,14 @@ public class TokenManager {
 
         String newHashedParam = sha512Encoder.hash(data);
         if (!newHashedParam.equals(originalHashedParam)) throw TokenErrors.INCORRECT_SIGNATURE.toException();
+
         return true;
+    }
+
+    public void saveToken(String token) {
+        Token newToken = new Token();
+        newToken.setToken(token);
+        tokenRepository.save(newToken);
     }
 
 }

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/TokenRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/encrypt/TokenRepository.java
@@ -1,0 +1,7 @@
+package com.ddbb.dingdong.infrastructure.auth.encrypt;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenRepository extends CrudRepository<Token, Long> {
+    boolean existsByToken(String token);
+}


### PR DESCRIPTION
### 관련 이슈
- [x] #210 

### 구현 내용
- [x] Token 테이블을 생성합니다. (토큰 String을 unique 컬럼으로 지정합니다)
- [x] 결제시, 토큰이 DB에있는지 확인후, 있다면 중복결제라는 에러를 반환합니다. 결제후, 토큰을 DB에 저장합니다.

### 개선해야 할 사항
- 현재는 중복 결제만 막기위해 이러한 기능을 도입하였습니다.
- 그러나 토큰이 무한히 쌓이는 문제가 발생할것같고, 이를 30분마다 삭제하는 배치작업도 현재 우리서버에 띄우기는 부담스러운 상황입니다.
- 차선책으로, 결제 로그 테이블에 결제 token 컬럼을 추가하고, 결제할때마다 해당 토큰값을 로그 테이블에 함께 저장합니다. 추후에 결제시 해당 토큰컬럼이 있는지 확인하는 방식으로 검증한다면 추가 테이블 생성없이 구현할 수 있을 것 같습니다. (이에 대해 어떤 생각이신지 의견을 묻고 싶어요 @ji-woong-song @popopy0412)
- 결제 로그가 많이 쌓일 경우를 대비해, 결제로그의 token 컬럼에 인덱스를 부여하는 방식으로 성능 비교를 해보고 도입하면 될 것 같습니다.