### PR TITLE
[BE] 데이터를 마련하기 위한 API 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/FastSignUpUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/FastSignUpUseCase.java
@@ -1,0 +1,64 @@
+package com.ddbb.dingdong.application.usecase.user;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.auth.service.error.AuthErrors;
+import com.ddbb.dingdong.domain.payment.entity.Wallet;
+import com.ddbb.dingdong.domain.payment.repository.WalletRepository;
+import com.ddbb.dingdong.domain.user.entity.Home;
+import com.ddbb.dingdong.domain.user.entity.School;
+import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.repository.SchoolRepository;
+import com.ddbb.dingdong.domain.user.repository.UserRepository;
+import com.ddbb.dingdong.infrastructure.auth.encrypt.PasswordEncoder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+public class FastSignUpUseCase implements UseCase<FastSignUpUseCase.Param, Void> {
+    private static final int INFINITE_MONEY = 1_000_000_000;
+
+    private final UserRepository userRepository;
+    private final SchoolRepository schoolRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final WalletRepository walletRepository;
+
+    @Override
+    public Void execute(Param param) {
+        String password = passwordEncoder.encode(param.getPassword());
+        School school = schoolRepository.findById(1L)
+                .orElseThrow(AuthErrors.SCHOOL_NOT_FOUND::toException);
+        Home home = new Home(
+                null, 37.5143, 127.0294,
+                param.stationLatitude, param.stationLongitude,
+                "Test Station",
+                param.houseRoadNameAddress
+        );
+        User user = new User(
+                null, param.name, param.email, password, LocalDateTime.now(),
+                school,
+                home
+        );
+        user = userRepository.save(user);
+        Wallet wallet = new Wallet(null, user.getId(), INFINITE_MONEY, LocalDateTime.now(), new ArrayList<>());
+        walletRepository.save(wallet);
+        return null;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private String name;
+        private String email;
+        private String password;
+        private String houseRoadNameAddress;
+        private Double stationLatitude;
+        private Double stationLongitude;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserRepository.java
@@ -1,13 +1,17 @@
 package com.ddbb.dingdong.domain.user.repository;
 
 import com.ddbb.dingdong.domain.user.entity.User;
-import com.ddbb.dingdong.domain.user.repository.projection.HomeLocationProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    @Query("SELECT u FROM User u " +
+            "JOIN FETCH School school ON school.id = u.school.id " +
+            "JOIN FETCH Home home ON home.id = u.home.id ")
+    List<User> findAllUser();
 }

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/AdminUserTestController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/AdminUserTestController.java
@@ -1,0 +1,39 @@
+package com.ddbb.dingdong.presentation.endpoint.admin.temp;
+
+import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.repository.UserRepository;
+import com.ddbb.dingdong.infrastructure.auth.AuthUser;
+import com.ddbb.dingdong.infrastructure.auth.annotation.LoginUser;
+import com.ddbb.dingdong.presentation.endpoint.admin.temp.dto.GetUserInfoDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/test/users")
+public class AdminUserTestController {
+    private final UserRepository userRepository;
+
+    @GetMapping("/all")
+    public ResponseEntity<GetUserInfoDTO> getAllUsers(
+            @LoginUser AuthUser admin
+    ) {
+        List<User> users = userRepository.findAllUser();
+        List<GetUserInfoDTO.Item> userInfoList = users.stream()
+                .map(user -> new GetUserInfoDTO.Item(
+                        user.getId(),
+                        user.getHome().getHouseLongitude(),
+                        user.getHome().getHouseLatitude(),
+                        user.getHome().getStationLongitude(),
+                        user.getHome().getStationLatitude(),
+                        user.getHome().getStationName(),
+                        user.getEmail()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(new GetUserInfoDTO(userInfoList));
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/AdminUserTestController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/AdminUserTestController.java
@@ -1,11 +1,16 @@
 package com.ddbb.dingdong.presentation.endpoint.admin.temp;
 
+import com.ddbb.dingdong.application.exception.APIException;
+import com.ddbb.dingdong.application.usecase.user.ChangeUserStationUseCase;
+import com.ddbb.dingdong.domain.common.exception.DomainException;
 import com.ddbb.dingdong.domain.user.entity.User;
 import com.ddbb.dingdong.domain.user.repository.UserRepository;
 import com.ddbb.dingdong.infrastructure.auth.AuthUser;
 import com.ddbb.dingdong.infrastructure.auth.annotation.LoginUser;
 import com.ddbb.dingdong.presentation.endpoint.admin.temp.dto.GetUserInfoDTO;
+import com.ddbb.dingdong.presentation.endpoint.admin.temp.dto.UserHomeUpdateDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/test/users")
 public class AdminUserTestController {
+    private final ChangeUserStationUseCase changeUserStationUseCase;
     private final UserRepository userRepository;
 
     @GetMapping("/all")
@@ -35,5 +41,24 @@ public class AdminUserTestController {
                 .toList();
 
         return ResponseEntity.ok(new GetUserInfoDTO(userInfoList));
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> putHomeLocation(
+            @RequestBody UserHomeUpdateDTO dto
+    ) {
+        ChangeUserStationUseCase.Param param = new ChangeUserStationUseCase.Param(
+                dto.getUserId(),
+                dto.getStationName(),
+                dto.getStationRoadAddressName(),
+                dto.getStationLatitude(),
+                dto.getStationLongitude()
+        );
+        try {
+            changeUserStationUseCase.execute(param);
+            return null;
+        } catch (DomainException e) {
+            throw new APIException(e, HttpStatus.BAD_REQUEST);
+        }
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/AdminUserTestController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/AdminUserTestController.java
@@ -2,11 +2,13 @@ package com.ddbb.dingdong.presentation.endpoint.admin.temp;
 
 import com.ddbb.dingdong.application.exception.APIException;
 import com.ddbb.dingdong.application.usecase.user.ChangeUserStationUseCase;
+import com.ddbb.dingdong.application.usecase.user.FastSignUpUseCase;
 import com.ddbb.dingdong.domain.common.exception.DomainException;
 import com.ddbb.dingdong.domain.user.entity.User;
 import com.ddbb.dingdong.domain.user.repository.UserRepository;
 import com.ddbb.dingdong.infrastructure.auth.AuthUser;
 import com.ddbb.dingdong.infrastructure.auth.annotation.LoginUser;
+import com.ddbb.dingdong.presentation.endpoint.admin.temp.dto.FastSignUpDTO;
 import com.ddbb.dingdong.presentation.endpoint.admin.temp.dto.GetUserInfoDTO;
 import com.ddbb.dingdong.presentation.endpoint.admin.temp.dto.UserHomeUpdateDTO;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/test/users")
 public class AdminUserTestController {
+    private final FastSignUpUseCase fastSignUpUseCase;
     private final ChangeUserStationUseCase changeUserStationUseCase;
     private final UserRepository userRepository;
 
@@ -56,6 +59,26 @@ public class AdminUserTestController {
         );
         try {
             changeUserStationUseCase.execute(param);
+            return null;
+        } catch (DomainException e) {
+            throw new APIException(e, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @PostMapping("/fast-signup")
+    public ResponseEntity<Void> postHomeLocation(
+            @RequestBody FastSignUpDTO dto
+    ) {
+        try {
+            FastSignUpUseCase.Param param = new FastSignUpUseCase.Param(
+                    dto.getName(),
+                    dto.getEmail(),
+                    dto.getPassword(),
+                    dto.getHouseRoadNameAddress(),
+                    dto.getStationLatitude(),
+                    dto.getStationLongitude()
+            );
+            fastSignUpUseCase.execute(param);
             return null;
         } catch (DomainException e) {
             throw new APIException(e, HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/dto/FastSignUpDTO.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/dto/FastSignUpDTO.java
@@ -1,0 +1,17 @@
+package com.ddbb.dingdong.presentation.endpoint.admin.temp.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FastSignUpDTO {
+    private String name;
+    private String email;
+    private String password;
+    private Double stationLatitude;
+    private Double stationLongitude;
+    private String houseRoadNameAddress;
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/dto/GetUserInfoDTO.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/dto/GetUserInfoDTO.java
@@ -1,0 +1,27 @@
+package com.ddbb.dingdong.presentation.endpoint.admin.temp.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetUserInfoDTO {
+    private List<Item> items;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Item {
+        private Long userId;
+        private Double houseLongitude;
+        private Double houseLatitude;
+        private Double stationLongitude;
+        private Double stationLatitude;
+        private String stationName;
+        private String email;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/dto/UserHomeUpdateDTO.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/temp/dto/UserHomeUpdateDTO.java
@@ -1,0 +1,12 @@
+package com.ddbb.dingdong.presentation.endpoint.admin.temp.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserHomeUpdateDTO {
+    private Long userId;
+    private Double stationLatitude;
+    private Double stationLongitude;
+    private String stationName;
+    private String stationRoadAddressName;
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/exchanges/SignUpRequestDto.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/exchanges/SignUpRequestDto.java
@@ -1,5 +1,6 @@
 package com.ddbb.dingdong.presentation.endpoint.auth.exchanges;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
@@ -11,6 +12,7 @@ public class SignUpRequestDto {
     private Long schoolId;
 
     @Data
+    @AllArgsConstructor
     public static class Home {
         private Double houseLatitude;
         private Double houseLongitude;


### PR DESCRIPTION
## 관련 이슈
- #197 

## 구현 사항
- 유저의 정류장 위치를 관리자 마음대로 바꿀 수 있는 test 편의용 API를 구현했습니다.
- 유저의 정류장 위치를 관리자 마음대로 넣어 새 유저를 만들 수 있는 test 편의용 API를 구현했습니다.
- 모든 유저 정보를 조회할 수 있는 test 편의용 API를 구현했습니다.

## 전달 사항
모든 test 편의용 API들은 AdminUserTestController에 구현하였으며 운영 시작 할 때에는 비활성화 또는 제거될 예정입니다.

