### PR TITLE
[BE] 유저가 타야할 정류장 정보 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetBusStopLocationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetBusStopLocationUseCase.java
@@ -1,0 +1,30 @@
+package com.ddbb.dingdong.application.usecase.bus;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetBusStopLocationUseCase implements UseCase<GetBusStopLocationUseCase.Param, GetBusStopLocationUseCase.Response> {
+    @Override
+    public Response execute(Param param) {
+        return null;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private Long userId;
+        private Long busScheduleId;
+    }
+
+    @AllArgsConstructor
+    public static class Response {
+        private Double longitude;
+        private Double latitude;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetBusStopLocationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetBusStopLocationUseCase.java
@@ -2,6 +2,9 @@ package com.ddbb.dingdong.application.usecase.bus;
 
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.transportation.repository.BusScheduleQueryRepository;
+import com.ddbb.dingdong.domain.transportation.repository.projection.BusStopLocationProjection;
+import com.ddbb.dingdong.domain.transportation.service.BusErrors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,9 +13,16 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class GetBusStopLocationUseCase implements UseCase<GetBusStopLocationUseCase.Param, GetBusStopLocationUseCase.Response> {
+    private final BusScheduleQueryRepository busScheduleQueryRepository;
+
     @Override
     public Response execute(Param param) {
-        return null;
+        BusStopLocationProjection busStopLocation = busScheduleQueryRepository.findBusStopLocation(param.userId, param.busScheduleId)
+                .orElseThrow(BusErrors.NO_BUS_STOP::toException);
+        return new Response(
+                busStopLocation.getLongitude(),
+                busStopLocation.getLatitude()
+        );
     }
 
     @Getter
@@ -22,6 +32,7 @@ public class GetBusStopLocationUseCase implements UseCase<GetBusStopLocationUseC
         private Long busScheduleId;
     }
 
+    @Getter
     @AllArgsConstructor
     public static class Response {
         private Double longitude;

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleQueryRepository.java
@@ -2,6 +2,7 @@ package com.ddbb.dingdong.domain.transportation.repository;
 
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
 import com.ddbb.dingdong.domain.transportation.repository.projection.BusReservedSeatProjection;
+import com.ddbb.dingdong.domain.transportation.repository.projection.BusStopLocationProjection;
 import com.ddbb.dingdong.domain.transportation.repository.projection.ScheduleTimeProjection;
 import jakarta.persistence.LockModeType;
 import com.ddbb.dingdong.domain.transportation.repository.projection.UserBusStopProjection;
@@ -47,4 +48,16 @@ public interface BusScheduleQueryRepository extends JpaRepository<BusSchedule, L
             "WHERE bs.id = :busScheduleId " +
             "ORDER BY busStop.sequence")
     List<UserBusStopProjection> findUserBusStops(@Param("busScheduleId") Long busScheduleId);
+
+    @Query("SELECT busStop.longitude as longitude, busStop.latitude as latitude " +
+            "FROM Ticket ticket " +
+            "JOIN BusSchedule busSchedule ON busSchedule.id = ticket.busScheduleId " +
+            "JOIN Reservation reservation ON reservation.id = ticket.reservation.id " +
+            "JOIN BusStop busStop ON busStop.id = ticket.busStopId " +
+            "WHERE reservation.userId = :userId AND busSchedule.id = :busScheduleId"
+    )
+    Optional<BusStopLocationProjection> findBusStopLocation(
+            @Param("userId") Long userId,
+            @Param("busScheduleId") Long busScheduleId
+    );
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/BusStopLocationProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/BusStopLocationProjection.java
@@ -1,0 +1,6 @@
+package com.ddbb.dingdong.domain.transportation.repository.projection;
+
+public interface BusStopLocationProjection {
+    Double getLatitude();
+    Double getLongitude();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusErrors.java
@@ -8,6 +8,7 @@ public enum BusErrors implements ErrorInfo {
     NO_SOCKET_CONNECTION("연결된 소켓이 없습니다."),
     BUS_UPDATE_ERROR("정류장 도착 예정 시간 업데이트 도중 오류가 발생했습니다."),
     NO_BUS_FOUND("조건에 만족하는 버스가 존재하지 않습니다."),
+    NO_BUS_STOP("조건에 맞는 버스 정류장이 없습니다."),
     NO_SEATS("남은 좌석이 없습니다."),
     ;
     private final String desc;

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/bus/BusController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/bus/BusController.java
@@ -3,6 +3,7 @@ package com.ddbb.dingdong.presentation.endpoint.bus;
 import com.ddbb.dingdong.application.exception.APIException;
 import com.ddbb.dingdong.application.usecase.bus.GetAvailableBusLine;
 import com.ddbb.dingdong.application.usecase.bus.GetBusSchedulesUseCase;
+import com.ddbb.dingdong.application.usecase.bus.GetBusStopLocationUseCase;
 import com.ddbb.dingdong.application.usecase.bus.GetPathPointLine;
 import com.ddbb.dingdong.domain.common.exception.DomainException;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
@@ -23,6 +24,7 @@ public class BusController {
     private final GetBusSchedulesUseCase getBusSchedulesUseCase;
     private final GetAvailableBusLine getAvailableBusLine;
     private final GetPathPointLine getPathPointLine;
+    private final GetBusStopLocationUseCase getBusStopLocationUseCase;
 
     @GetMapping("/schedule/time")
     public ResponseEntity<GetBusSchedulesUseCase.Response> getBusSchedules(
@@ -61,6 +63,19 @@ public class BusController {
             GetPathPointLine.Param param = new GetPathPointLine.Param(busScheduleId);
             GetPathPointLine.Response result = getPathPointLine.execute(param);
             return ResponseEntity.ok(result);
+        } catch (DomainException e) {
+            throw new APIException(e, HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @GetMapping("/bus-stop/location/{busScheduleId}")
+    public ResponseEntity<GetBusStopLocationUseCase.Response> getBusStopLocation(
+            @LoginUser AuthUser authUser,
+            @PathVariable("busScheduleId") Long busScheduleId
+    ) {
+        try {
+            GetBusStopLocationUseCase.Param param = new GetBusStopLocationUseCase.Param(authUser.id(), busScheduleId);
+            return ResponseEntity.ok(getBusStopLocationUseCase.execute(param));
         } catch (DomainException e) {
             throw new APIException(e, HttpStatus.NOT_FOUND);
         }


### PR DESCRIPTION
## 관련 이슈
- #196 

## 구현 사항
- 버스 스케쥴 아이디를 path variable로 주면 그 운행표에 타야할 버스 정류장 위치를 반환합니다

## 전달 사항
- 홈 화면 / 예약 내역 화면에서 필요 없어서 전달하지 않았던 버스 정류장 위치 정보를 조회하는 API 입니다.
- 실시간 버스 위치 확인 및 경로 확인 페이지에서 필요하여 구현했습니다.
