### PR TITLE
[BE] 버스 운행 종료 API 추가 및 버스 운행 시작 API 변경

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StartBusUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StartBusUseCase.java
@@ -2,6 +2,7 @@ package com.ddbb.dingdong.application.usecase.bus;
 
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
 import com.ddbb.dingdong.domain.transportation.repository.BusScheduleQueryRepository;
 import com.ddbb.dingdong.domain.transportation.repository.projection.UserBusStopProjection;
 import com.ddbb.dingdong.domain.transportation.service.BusErrors;
@@ -34,6 +35,7 @@ public class StartBusUseCase implements UseCase<StartBusUseCase.Param, Void> {
         if (projections.isEmpty()) {
             throw BusErrors.NO_BUS_FOUND.toException();
         }
+        busScheduleManagement.updateBusSchedule(param.busScheduleId, OperationStatus.RUNNING);
         Map<Long, UserBusStopTime> busStopTimeMap = new LinkedHashMap<>();
         for (UserBusStopProjection proj : projections) {
             if (!busStopTimeMap.containsKey(proj.getBusStopId())) {

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StopBusUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StopBusUseCase.java
@@ -1,0 +1,32 @@
+package com.ddbb.dingdong.application.usecase.bus;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
+import com.ddbb.dingdong.domain.transportation.service.BusScheduleManagement;
+import com.ddbb.dingdong.infrastructure.bus.simulator.subscription.BusSubscriptionManager;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StopBusUseCase implements UseCase<StopBusUseCase.Param, Void> {
+    private final BusSubscriptionManager subscriptionManager;
+    private final BusScheduleManagement busScheduleManagement;
+    @Override
+    @Transactional
+    public Void execute(Param param) {
+        busScheduleManagement.updateBusSchedule(param.busScheduleId, OperationStatus.ENDED);
+        subscriptionManager.cleanPublisher(param.busScheduleId);
+        return null;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private Long busScheduleId;
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleRepository.java
@@ -1,6 +1,7 @@
 package com.ddbb.dingdong.domain.transportation.repository;
 
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
+import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,5 +17,12 @@ public interface BusScheduleRepository extends JpaRepository<BusSchedule, Long> 
     int updateBusStopArrivalTime(
             @Param("newArrivalTime") LocalDateTime newArrivalTime,
             @Param("busStopId") Long busStopId
+    );
+
+    @Modifying
+    @Query("UPDATE BusSchedule busSchedule SET busSchedule.status = :status WHERE busSchedule.id = :busScheduleId")
+    int updateBusScheduleStats(
+            @Param("busScheduleId") Long busScheduleId,
+            @Param("status") OperationStatus status
     );
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusErrors.java
@@ -9,6 +9,7 @@ public enum BusErrors implements ErrorInfo {
     BUS_UPDATE_ERROR("정류장 도착 예정 시간 업데이트 도중 오류가 발생했습니다."),
     NO_BUS_FOUND("조건에 만족하는 버스가 존재하지 않습니다."),
     NO_SEATS("남은 좌석이 없습니다."),
+    BUS_SCHEDULE_UPDATE_ERR("버스 운행 상태 업데이트 도중 오류가 발생했습니다.")
     ;
     private final String desc;
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusScheduleManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusScheduleManagement.java
@@ -75,7 +75,6 @@ public class BusScheduleManagement {
     }
 
     // TODO:: bulk update
-    @Transactional
     public void updateBusStopTimes(List<UserBusStopTime> userBusStopTimes, List<UserBusStopTime> oldUserBusStopTimes) {
         for (int i = 0; i < userBusStopTimes.size(); i++) {
             UserBusStopTime oldUserBusStopTime = oldUserBusStopTimes.get(i);
@@ -89,7 +88,6 @@ public class BusScheduleManagement {
         }
     }
 
-    @Transactional
     public void updateBusSchedule(Long busScheduleId, OperationStatus status) {
         int result = busScheduleRepository.updateBusScheduleStats(busScheduleId, status);
         if (result == 0) {

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusScheduleManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusScheduleManagement.java
@@ -89,6 +89,14 @@ public class BusScheduleManagement {
         }
     }
 
+    @Transactional
+    public void updateBusSchedule(Long busScheduleId, OperationStatus status) {
+        int result = busScheduleRepository.updateBusScheduleStats(busScheduleId, status);
+        if (result == 0) {
+            throw BUS_UPDATE_ERROR.toException();
+        }
+    }
+
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void publishDepartureEvent(List<UserBusStopTime> userBusStopTimes) {
         for (UserBusStopTime userBusStopTime : userBusStopTimes) {

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/BusAdminController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/BusAdminController.java
@@ -17,11 +17,14 @@ public class BusAdminController {
     private final StartBusUseCase startBusUseCase;
     private final StopBusUseCase stopBusUseCase;
 
-    @PostMapping("/start")
-    public ResponseEntity<Void> startBus(@RequestBody BusStartRequestDTO busStartRequestDTO) {
+    @PostMapping("/{busScheduleId}")
+    public ResponseEntity<Void> startBus(
+            @PathVariable("busScheduleId") Long busScheduleId,
+            @RequestBody BusStartRequestDTO busStartRequestDTO
+    ) {
         try {
             startBusUseCase.execute(new StartBusUseCase.Param(
-                    busStartRequestDTO.getBusScheduleId(),
+                    busScheduleId,
                     busStartRequestDTO.getInterval(),
                     busStartRequestDTO.getDelay(),
                     busStartRequestDTO.getTimeUnit()

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/BusAdminController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/BusAdminController.java
@@ -2,21 +2,20 @@ package com.ddbb.dingdong.presentation.endpoint.admin;
 
 import com.ddbb.dingdong.application.exception.APIException;
 import com.ddbb.dingdong.application.usecase.bus.StartBusUseCase;
+import com.ddbb.dingdong.application.usecase.bus.StopBusUseCase;
 import com.ddbb.dingdong.domain.common.exception.DomainException;
 import com.ddbb.dingdong.presentation.endpoint.admin.exchanges.BusStartRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/bus")
 public class BusAdminController {
     private final StartBusUseCase startBusUseCase;
+    private final StopBusUseCase stopBusUseCase;
 
     @PostMapping("/start")
     public ResponseEntity<Void> startBus(@RequestBody BusStartRequestDTO busStartRequestDTO) {
@@ -31,5 +30,18 @@ public class BusAdminController {
             throw new APIException(e, HttpStatus.NOT_FOUND);
         }
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{busScheduleId}")
+    public ResponseEntity<Void> stopBus(
+            @PathVariable("busScheduleId") Long busScheduleId
+    ) {
+        try {
+            StopBusUseCase.Param param = new StopBusUseCase.Param(busScheduleId);
+            stopBusUseCase.execute(param);
+            return ResponseEntity.ok().build();
+        } catch (DomainException e) {
+            throw new APIException(e, HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/exchanges/BusStartRequestDTO.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/admin/exchanges/BusStartRequestDTO.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 @Getter
 @NoArgsConstructor
 public class BusStartRequestDTO {
-    private Long busScheduleId;
     private Long interval = 1L;
     private Long delay = 0L;
     private TimeUnit timeUnit  = TimeUnit.SECONDS;


### PR DESCRIPTION
## 관련 이슈
- #134 
- #221 

## 구현 사항
- 버스 스케쥴 아이디를 path variable로 주면 해당 버스를 운행 종료하는 API를 구현했습니다.
- 버스 운행 종료 API에 맞게 버스 출발 API의 URL 및 요청 전달 형식을 변경했습니다.
- 버스 출발 API에서 버스 스케줄 상태를 RUNNING으로 바꾸는 부분을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced intelligent bus scheduling improvements using advanced clustering and route optimization for more efficient transport services.
  - Enhanced the reservation system with streamlined booking, cancellation, and group reservation processes.
  - Upgraded user authentication with rapid sign-up, robust email verification, and secure session management.
  - Added real-time notifications powered by WebSocket updates to keep users informed.
  - Rolled out new administrative tools for managing transport operations and monitoring service status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->