### PR TITLE
[BE] 예매 내역 조회 페이지네이션에서 totalElements를 잘못 가져오는 버그 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -13,46 +13,68 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReservationQueryRepository extends JpaRepository<Reservation, Long> {
-    @Query("""
-        SELECT DISTINCT l.stationName AS userHomeStationName,
-               r.id AS reservationId,
-               r.startDate AS startDate,
-               r.direction AS direction,
-               r.arrivalTime AS expectedArrivalTime,
-               r.departureTime AS expectedDepartureTime,
-               bs_arrival.departureTime AS realDepartureTime,
-               bs_arrival.arrivalTime AS realArrivalTime,
-               r.status AS reservationStatus,
-               bs_arrival.id AS busScheduleId,
-               b.name AS busName,
-               bs_arrival.status AS busStatus,
-               bs.roadNameAddress AS busStopRoadNameAddress,
-               bs.expectedArrivalTime AS busStopArrivalTime
-        FROM Reservation r
-        LEFT JOIN Ticket t ON r.id = t.reservation.id
-        LEFT JOIN BusStop bs ON t.busStopId = bs.id
-        LEFT JOIN BusSchedule bs_arrival ON bs_arrival.id = t.busScheduleId
-        LEFT JOIN Bus b ON bs_arrival.bus.id = b.id
-        LEFT JOIN Location l ON l.reservationId = r.id
-        WHERE r.userId = :userId
-            AND (
-                (:category = 0)
-                OR
-                (:category = 1 AND CAST(r.status AS STRING) = 'ALLOCATED')
-                OR
-                (:category = 2 AND CAST(r.status AS STRING) = 'PENDING')
-                OR
-                (:category = 3 AND CAST(r.status AS STRING) = 'FAIL_ALLOCATED')
-                OR
-                (:category = 4 AND CAST(bs_arrival.status AS STRING) = 'ENDED')
-                OR
-                (:category = 5 AND CAST(r.status AS STRING) = 'CANCELED')
-                OR
-                (:category = 6 AND (CAST(r.status AS STRING) = 'ALLOCATED' OR CAST(r.status AS STRING) = 'PENDING'))
-                )
-            ORDER BY
-               CASE WHEN :sort = 0 THEN r.startDate END DESC,
-               CASE WHEN :sort = 1 THEN r.startDate END ASC
-        """)
+    @Query(value = """
+    SELECT DISTINCT l.stationName AS userHomeStationName,
+           r.id AS reservationId,
+           r.startDate AS startDate,
+           r.direction AS direction,
+           r.arrivalTime AS expectedArrivalTime,
+           r.departureTime AS expectedDepartureTime,
+           bs_arrival.departureTime AS realDepartureTime,
+           bs_arrival.arrivalTime AS realArrivalTime,
+           r.status AS reservationStatus,
+           bs_arrival.id AS busScheduleId,
+           b.name AS busName,
+           bs_arrival.status AS busStatus,
+           bs.roadNameAddress AS busStopRoadNameAddress,
+           bs.expectedArrivalTime AS busStopArrivalTime
+    FROM Reservation r
+    LEFT JOIN Ticket t ON r.id = t.reservation.id
+    LEFT JOIN BusStop bs ON t.busStopId = bs.id
+    LEFT JOIN BusSchedule bs_arrival ON bs_arrival.id = t.busScheduleId
+    LEFT JOIN Bus b ON bs_arrival.bus.id = b.id
+    LEFT JOIN Location l ON l.reservationId = r.id
+    WHERE r.userId = :userId
+        AND (
+            (:category = 0)
+            OR
+            (:category = 1 AND CAST(r.status AS STRING) = 'ALLOCATED')
+            OR
+            (:category = 2 AND CAST(r.status AS STRING) = 'PENDING')
+            OR
+            (:category = 3 AND CAST(r.status AS STRING) = 'FAIL_ALLOCATED')
+            OR
+            (:category = 4 AND CAST(bs_arrival.status AS STRING) = 'ENDED')
+            OR
+            (:category = 5 AND CAST(r.status AS STRING) = 'CANCELED')
+            OR
+            (:category = 6 AND (CAST(r.status AS STRING) = 'ALLOCATED' OR CAST(r.status AS STRING) = 'PENDING'))
+        )
+    ORDER BY
+       CASE WHEN :sort = 0 THEN r.startDate END DESC,
+       CASE WHEN :sort = 1 THEN r.startDate END ASC
+    """,
+    countQuery = """
+    SELECT COUNT(DISTINCT r.id)
+    FROM Reservation r
+    LEFT JOIN Ticket t ON r.id = t.reservation.id
+    LEFT JOIN Location l ON l.reservationId = r.id
+    WHERE r.userId = :userId
+        AND (
+            (:category = 0)
+            OR
+            (:category = 1 AND CAST(r.status AS STRING) = 'ALLOCATED')
+            OR
+            (:category = 2 AND CAST(r.status AS STRING) = 'PENDING')
+            OR
+            (:category = 3 AND CAST(r.status AS STRING) = 'FAIL_ALLOCATED')
+            OR
+            (:category = 4 AND CAST(r.status AS STRING) = 'ENDED')
+            OR
+            (:category = 5 AND CAST(r.status AS STRING) = 'CANCELED')
+            OR
+            (:category = 6 AND (CAST(r.status AS STRING) = 'ALLOCATED' OR CAST(r.status AS STRING) = 'PENDING'))
+        )
+    """)
     Page<UserReservationProjection> queryReservationsByUserId(@Param("userId") Long userId, @Param("category") int category, @Param("sort") int sort, Pageable p);
 }


### PR DESCRIPTION
## 관련 이슈
- [x] #225 

## 원인 분석
- 페이지네이션을 처리할떄 사진과 같은 에러메세지가 출력되는것을 확인하였습니다.
<img width="1180" alt="스크린샷 2025-02-16 오전 1 27 20" src="https://github.com/user-attachments/assets/eadcb643-9784-46be-98a5-d5ac53937b47" />
<br><br><br>
sort는 아래와같이 ORDER BY절에서 사용하고 있었고, 오타도 없고 아무런 이상이없었는데 :sort를 바인딩하지 못했다는 오류가 나는것이 이상했습니다.<br>
<img width="541" alt="스크린샷 2025-02-16 오전 1 29 10" src="https://github.com/user-attachments/assets/5c4390d3-9990-4680-924a-0a2d45b4c497" />


<br><br><br>

페이지네이션처리를할때, 내부적으로 총 두번의 쿼리가 필요합니다.
1. 페이지 만큼의 데이터를 가져오는 select 문
2. 총 elements를 확인하는 count 쿼리 문

JPA에서 (2)번을 처리할때 **내부적으로 ORDER BY를 제거하고 쿼리를 실행한다고 합니다** 
ORDER BY를 제거하면서, `@Param("sort") int sort` 로 사용되었던 쿼리파라미터가 사용되지않게되고, binding실패로 count 쿼리 자체가 에러가 나서 실행되지 않게됩니다.

그렇게되면 totalElements의 값에, 현재 페이지된 리스트의 elements수가 들어가게되어 해당 문제가 발생하는것이었습니다.

즉, 메인 쿼리와 함께 전달된 모든 파라미터(userId, category, sort)를 count 쿼리에도 바인딩하려 시도하는데,
count 쿼리에는 실제로 :sort가 존재하지 않으므로 바인딩 시점에 "No parameter named ':sort'" 오류가 발생시키는 것이었습니다.

### 해결 방법

JPA에서 @Query 어노테이션에 countQuery를 명시적으로 지정하면, 페이징을 위해 전체 개수를 계산할 때 자동으로 생성되는 count 쿼리 대신 해당 countQuery를 그대로 사용합니다.

즉, <br>

<img width="899" alt="스크린샷 2025-02-16 오전 1 39 41" src="https://github.com/user-attachments/assets/7cc0caf9-118e-47e0-90cf-70583a375285" />

<br>
과 같이 countQuery를 명시적으로 지정하면, :sort는 사용되지않고, 바인딩되지도 않아 올바른 count query를 실행하게되고, 버그는 해결되었습니다.

