### PR TITLE
[BE] 예매 취소 url 변경

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/ReservationController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/ReservationController.java
@@ -47,13 +47,12 @@ public class ReservationController {
         return ResponseEntity.ok(result);
     }
 
-    @DeleteMapping
+    @DeleteMapping("/{reservationId}")
     public ResponseEntity<Void> cancelReservation(
             @LoginUser AuthUser user,
-            @RequestBody ReservationCancelDTO reservationCancelDTO
+            @PathVariable Long reservationId
     ) {
         Long userId = user.id();
-        Long reservationId = reservationCancelDTO.getReservationId();
         CancelReservationUseCase.Param param = new CancelReservationUseCase.Param(
                 userId,
                 reservationId

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/exchanges/ReservationCancelDTO.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/exchanges/ReservationCancelDTO.java
@@ -1,8 +1,0 @@
-package com.ddbb.dingdong.presentation.endpoint.reservation.exchanges;
-
-import lombok.Getter;
-
-@Getter
-public class ReservationCancelDTO {
-    private Long reservationId;
-}


### PR DESCRIPTION
### 관련 이슈
- [x] #231 

- requestbody로 전달하던 reservationId를 PathVariable로 대체
- 기존 reservationCancelDTO는 pathvariable로 대체되어, 파일삭제