### PR TITLE
[BE] User 테이블에 Role 추가

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/ApplicationInitializer.java
+++ b/backend/src/main/java/com/ddbb/dingdong/ApplicationInitializer.java
@@ -5,6 +5,7 @@ import com.ddbb.dingdong.domain.payment.repository.WalletRepository;
 import com.ddbb.dingdong.domain.user.entity.Home;
 import com.ddbb.dingdong.domain.user.entity.School;
 import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.entity.vo.Role;
 import com.ddbb.dingdong.domain.user.repository.SchoolRepository;
 import com.ddbb.dingdong.domain.user.repository.UserRepository;
 import com.ddbb.dingdong.infrastructure.auth.encrypt.PasswordEncoder;
@@ -24,9 +25,15 @@ public class ApplicationInitializer {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final WalletRepository walletRepository;
+    private static final String adminEmail = "admin@admin.com";
 
     @PostConstruct
     public void init() {
+
+        if(userRepository.findByEmail(adminEmail).isEmpty()) {
+            adminSignUp();
+        }
+
         if (userRepository.findByEmail("test@test.com").isEmpty()) {
             String password = passwordEncoder.encode("abcd1234!@");
             School school = new School(null, "서울대학교", "서울대학교", 37.4602, 126.9527);
@@ -38,10 +45,21 @@ public class ApplicationInitializer {
         }
     }
 
+    private void adminSignUp() {
+        School school = new School();
+        school.setId(1L);
+        Home home = new Home(null, 37.5143, 127.0294, 37.513716, 127.029790, "에티버스" ,"학동로 180");
+        User user = new User(null, "admin", "admin@admin.com", "abcd1234!@", Role.ADMIN, LocalDateTime.now(), school, null);
+        user.associateHome(home);
+        user = userRepository.save(user);
+        Wallet wallet = new Wallet(null, user.getId(), 1000000, LocalDateTime.now(), new ArrayList<>());
+        walletRepository.save(wallet);
+    }
+
     private void autoSignUp(int testId, String password, School school) {
         Home home = new Home(null, 37.5143, 127.0294, 37.513716, 127.029790, "에티버스" ,"학동로 180");
         String email = testId == 0 ? "test@test.com" : "test" +testId + "@test.com";
-        User user = new User(null, "test", email, password, LocalDateTime.now(), school, null);
+        User user = new User(null, "test", email, password, Role.USER, LocalDateTime.now(), school, null);
         user.associateHome(home);
         user = userRepository.save(user);
         Wallet wallet = new Wallet(null, user.getId(), 50000, LocalDateTime.now(), new ArrayList<>());

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/FastSignUpUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/user/FastSignUpUseCase.java
@@ -8,6 +8,7 @@ import com.ddbb.dingdong.domain.payment.repository.WalletRepository;
 import com.ddbb.dingdong.domain.user.entity.Home;
 import com.ddbb.dingdong.domain.user.entity.School;
 import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.entity.vo.Role;
 import com.ddbb.dingdong.domain.user.repository.SchoolRepository;
 import com.ddbb.dingdong.domain.user.repository.UserRepository;
 import com.ddbb.dingdong.infrastructure.auth.encrypt.PasswordEncoder;
@@ -41,7 +42,7 @@ public class FastSignUpUseCase implements UseCase<FastSignUpUseCase.Param, Void>
                 param.houseRoadNameAddress
         );
         User user = new User(
-                null, param.name, param.email, password, LocalDateTime.now(),
+                null, param.name, param.email, password, Role.USER, LocalDateTime.now(),
                 school,
                 home
         );

--- a/backend/src/main/java/com/ddbb/dingdong/domain/auth/service/AuthManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/auth/service/AuthManagement.java
@@ -7,6 +7,7 @@ import com.ddbb.dingdong.domain.payment.repository.WalletRepository;
 import com.ddbb.dingdong.domain.user.entity.Home;
 import com.ddbb.dingdong.domain.user.entity.School;
 import com.ddbb.dingdong.domain.user.entity.User;
+import com.ddbb.dingdong.domain.user.entity.vo.Role;
 import com.ddbb.dingdong.domain.user.repository.SchoolRepository;
 import com.ddbb.dingdong.domain.user.repository.UserRepository;
 import com.ddbb.dingdong.infrastructure.auth.AuthUser;
@@ -52,6 +53,7 @@ public class AuthManagement {
                 ))
                 .createdAt(LocalDateTime.now())
                 .school(school)
+                .role(Role.USER)
                 .build();
         user = userRepository.save(user);
         Wallet wallet = new Wallet(null, user.getId(), WELCOME_MONEY, LocalDateTime.now(), new ArrayList<>());

--- a/backend/src/main/java/com/ddbb/dingdong/domain/auth/service/AuthManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/auth/service/AuthManagement.java
@@ -65,7 +65,7 @@ public class AuthManagement {
     public void login(String email, String password) {
         User user = userRepository.findByEmail(email).orElseThrow(AuthErrors.USER_NOT_FOUND::toException);
         if(!passwordEncoder.matches(password, user.getPassword())) throw AuthErrors.NOT_MATCHED_PASSWORD.toException();
-        authenticationManager.setAuthentication(new AuthUser(user.getId(), user.getSchool().getId()));
+        authenticationManager.setAuthentication(new AuthUser(user.getId(), user.getSchool().getId(), user.getRole()));
     }
 
     public void logout(Long userId) {

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/User.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.ddbb.dingdong.domain.user.entity;
 
+import com.ddbb.dingdong.domain.user.entity.vo.Role;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +27,10 @@ public class User {
 
     @Column(nullable = false)
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
     @Column(updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/vo/Role.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/entity/vo/Role.java
@@ -1,0 +1,6 @@
+package com.ddbb.dingdong.domain.user.entity.vo;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/AuthUser.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/auth/AuthUser.java
@@ -1,3 +1,5 @@
 package com.ddbb.dingdong.infrastructure.auth;
 
-public record AuthUser(Long id, Long schoolId) { }
+import com.ddbb.dingdong.domain.user.entity.vo.Role;
+
+public record AuthUser(Long id, Long schoolId, Role role) { }


### PR DESCRIPTION
## 관련이슈
- [x] #228 

## 변경 사항
- Application initializer에서, admin 전용 계정을 하나 더 추가하였습니다
- Role은 `ADMIN`, `USER` 두가지 타입만 존재합니다.

## 전달 사항
- 아직 Role에따른 api 인가는 구현하지 않은 상태입니다.