### PR TITLE
[FE] - 함께 타기 예매 정보 세션스토리지 추가, 모달 계속 html에 추가되는 문제 수정

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -117,6 +117,7 @@ export const router = createBrowserRouter([
         // 탑승지 위치 설정
         path: "set-home-location",
         Component: SetHomeLocation,
+        loader: createLoader(() => [users_home_locations()]),
       },
       {
         // 버스 예매하기

--- a/src/pages/BusBooking/CustomRouteBooking/page.tsx
+++ b/src/pages/BusBooking/CustomRouteBooking/page.tsx
@@ -27,11 +27,11 @@ import { convertIsoToDateObject } from "@/utils/calendar/timeViewBottomModalUtil
 import { mountModal } from "@/components/Loading";
 import Modal from "@/components/Modal";
 import { useLoaderData, useNavigate } from "react-router-dom";
-
+const { render } = mountModal();
 export default function CustomRouteBooking() {
   const [selectedTimeSchedule, dispatch] = useReducer(timeScheduleReducer, {});
   const navigate = useNavigate();
-  const { render } = mountModal();
+
   const [
     { schoolName },
     {

--- a/src/pages/BusBooking/FixedRouteBooking/page.tsx
+++ b/src/pages/BusBooking/FixedRouteBooking/page.tsx
@@ -46,7 +46,7 @@ export type timeType = {
   hour: number;
   minute: number;
 };
-
+const { render } = mountModal();
 export default function FixedRouteBooking() {
   // 예매 나가기 모달 상태관리
 
@@ -72,8 +72,6 @@ export default function FixedRouteBooking() {
       : TEMP_DATE;
 
   const busTimeScheduleObjectArray = transformSchedules(busTimeSchedule);
-
-  const { render } = mountModal();
 
   const exitButtonHandler = () => {
     // 모달 오픈. ( 예매를 취소 하시겠어요 ?)
@@ -102,8 +100,6 @@ export default function FixedRouteBooking() {
     );
   }, [selectedDate]);
 
-  
-
   useEffect(() => {
     if (selectedDate && selectedHourMinute) {
       setShowInfo(convertInfoToText(selectedDate, selectedHourMinute));
@@ -120,6 +116,7 @@ export default function FixedRouteBooking() {
       selectedDate!,
       selectedHourMinute!
     );
+    console.log(selectTimeScheduleArray, "이게 뭐징?");
     const direction = commuteType === "등교" ? "TO_SCHOOL" : "TO_HOME";
 
     navigateCustom("/fixed-bus-select-bus", {

--- a/src/pages/BusBooking/FixedRouteBookingSelectBus/components/BottomModal/index.tsx
+++ b/src/pages/BusBooking/FixedRouteBookingSelectBus/components/BottomModal/index.tsx
@@ -21,6 +21,7 @@ import {
 import OutlineButton from "@/components/designSystem/Button/OutlineButton";
 import { useNavigate } from "react-router-dom";
 import BusIcon from "@/components/designSystem/Icons/Home/BusIcon";
+import { useCustomNavigate } from "@/hooks/useNavigate";
 // import { useGetBusRouteCoordinates } from "@/hooks/BusBooking/useFixedBooking";
 
 interface BusStop {
@@ -55,6 +56,7 @@ export default function BusSelectBottomModal({
   setSelectedBusCardIndex,
 }: BusSelectBottomModalProps) {
   const navigate = useNavigate();
+  const navigateCustom = useCustomNavigate();
 
   const convertISOToHourMinute = (ISODate: string) => {
     const date = new Date(ISODate);
@@ -70,6 +72,20 @@ export default function BusSelectBottomModal({
   const departOrArrival = direction === "TO_SCHOOL" ? "출발" : "도착";
   // 탑승, 하차
   const boardingOrGetOff = direction === "TO_SCHOOL" ? "탑승" : "하차";
+
+  console.log(busInfoArray[selectedBusCardIndex], "정보정보");
+  // navigateCustom("/fixed-bus-select-bus", {
+  //   direction,
+  //   timeSchedule: selectTimeScheduleArray[0],
+  // });
+  const nextClickHandler = () => {
+    navigateCustom("/payment/purchase", {
+      direction,
+      timeSchedule: busInfoArray[selectedBusCardIndex].busStop.time,
+      busId: busInfoArray[selectedBusCardIndex].busScheduleId,
+      busStopName: busInfoArray[selectedBusCardIndex].busStop.name,
+    });
+  };
   return (
     <BottomModal showBottomSheet={true}>
       <BusCardTitle>
@@ -108,10 +124,7 @@ export default function BusSelectBottomModal({
       </BusCardWrapper>
       <BusSelectButtonStepWrapper>
         <OutlineButton text="이전" onClick={() => navigate(-1)} />
-        <SolidButton
-          text="다음"
-          onClick={() => navigate("/payment/purchase")}
-        />
+        <SolidButton text="다음" onClick={nextClickHandler} />
       </BusSelectButtonStepWrapper>
     </BottomModal>
   );


### PR DESCRIPTION
- 함께 타기 예매 정보 세션스토리지 추가
- 모달 계속 html에 추가되는 문제 수정 완료 했습니다!
세션 스토리지에 추가될 형태는 아래와 같습니다. [노션에도 반영](https://www.notion.so/bside/FE-URL-19a220202735807ca4f9db5af6825741?pvs=4)해두었어요!
```
'/fixed-bus-select-bus': 
{
direction: "TO_SCHOOL", 
timeSchedule: '2025-02-20T23:00:00.000Z',
busId: 1,
busStopName: "버스 정류장이름"
};
```