### PR TITLE
[BE] 함께타기 예매에서 탑승 가능한 버스 조회시, 버스 정류장 ID도 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
@@ -59,7 +59,7 @@ public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, G
                     .reservedSeat(count)
                     .totalSeat(15)
                     .build();
-            return new Response.Item(busStop.getBusScheduleId(), busStopInfo, busInfo);
+            return new Response.Item(busStop.getBusScheduleId(), busStop.getBusStopId(), busStopInfo, busInfo);
         })
         .toList();
         return new Response(items);
@@ -82,6 +82,7 @@ public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, G
         @AllArgsConstructor
         public static class Item {
             private Long busScheduleId;
+            private Long busStopId;
             private BusStopInfo busStop;
             private BusInfo busInfo;
         }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Repository
 public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
-    @Query("SELECT bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
+    @Query("SELECT bst.id as busStopId, bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
             "bst.expectedArrivalTime as busStopTime, b.name as busName, bs.id as busScheduleId " +
             "FROM BusStop bst " +
             "JOIN Ticket t ON t.busStopId = bst.id " +
@@ -25,7 +25,7 @@ public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
             @Param("schoolId") Long schoolId
     );
 
-    @Query("SELECT bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
+    @Query("SELECT bst.id as busStopId, bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
             "bst.expectedArrivalTime as busStopTime, b.name as busName, bs.id as busScheduleId " +
             "FROM BusStop bst " +
             "JOIN Ticket t ON t.busStopId = bst.id " +
@@ -33,7 +33,7 @@ public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
             "JOIN Bus b ON b.id = bs.bus.id " +
             "WHERE bs.arrivalTime = :arrivalTime AND bs.schoolId = :schoolId " +
             "AND bs.status = 'READY'")
-    List<AvailableBusStopProjection>  findAvailableGoSchoolBusStop(
+    List<AvailableBusStopProjection> findAvailableGoSchoolBusStop(
             @Param("arrivalTime") LocalDateTime arrivalTime,
             @Param("schoolId") Long schoolId
     );

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
@@ -3,6 +3,7 @@ package com.ddbb.dingdong.domain.transportation.repository.projection;
 import java.time.LocalDateTime;
 
 public interface AvailableBusStopProjection {
+    Long getBusStopId();
     LocalDateTime getBusStopTime();
     String getBusStopName();
     Double getLongitude();


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- [x] #237 
## 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- [x] 함께타기 예매에서 탑승 가능한 버스 조회시, 버스 정류장 ID도 반환하도록 쿼리문과 Projection을 수정했습니다.

## 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->