### PR TITLE
[BE] Page를 그대로 직렬화 했을때 직렬화에 실패하는 버그 해결

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/GetNotificationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/notification/GetNotificationsUseCase.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +32,7 @@ public class GetNotificationsUseCase implements UseCase<GetNotificationsUseCase.
         Page<Result.NotificationInfo> notificationInfos = getNotifications(userId, pageable);
         notificationManagement.readAllNotifications(userId);
 
-        return new Result(notificationInfos);
+        return new Result(new PagedModel<>(notificationInfos));
     }
 
     private Page<Result.NotificationInfo> getNotifications(Long userId, Pageable pageable) {
@@ -71,7 +72,7 @@ public class GetNotificationsUseCase implements UseCase<GetNotificationsUseCase.
     @Getter
     @AllArgsConstructor
     public static class Result {
-        private Page<NotificationInfo> notifications;
+        private PagedModel<NotificationInfo> notifications;
 
         @Getter
         @AllArgsConstructor

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,7 +75,7 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
                 })
                 .toList();
 
-        return new Result(new PageImpl<>(reservationInfos, param.pageable, result.getTotalElements()));
+        return new Result(new PagedModel<>(new PageImpl<>(reservationInfos, param.pageable, result.getTotalElements())));
     }
 
     @Getter
@@ -89,7 +90,7 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
     @Getter
     @AllArgsConstructor
     public static class Result {
-        private Page<ReservationInfo> reservationInfos;
+        private PagedModel<ReservationInfo> reservationInfos;
 
         @Getter
         @AllArgsConstructor

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/notification/NotificationController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/notification/NotificationController.java
@@ -27,10 +27,10 @@ public class NotificationController {
     public ResponseEntity<GetNotificationsUseCase.Result> getUserNotifications(
             @LoginUser AuthUser user,
             @RequestParam("page") int page,
-            @RequestParam("pageSize") int pageSize
+            @RequestParam(value = "pageSize", defaultValue = "-1") int pageSize
     ) {
         Long userid = user.id();
-        Pageable pageable = PageRequest.of(page, pageSize);
+        Pageable pageable = pageSize == -1 ? Pageable.unpaged() : PageRequest.of(page, pageSize);
         GetNotificationsUseCase.Param param = new GetNotificationsUseCase.Param(userid, pageable);
         GetNotificationsUseCase.Result result;
         try {

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/ReservationController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/ReservationController.java
@@ -34,7 +34,7 @@ public class ReservationController {
             @RequestParam int page,
             @RequestParam(defaultValue = "-1") int pageSize
     ) {
-        Pageable pageable = pageSize == -1 ? PageRequest.of(page, 1000) : PageRequest.of(page, pageSize);
+        Pageable pageable = pageSize == -1 ? Pageable.unpaged() : PageRequest.of(page, pageSize);
         Long userId = user.id();
         GetReservationsUseCase.Param param= new GetReservationsUseCase.Param(userId, pageable, sort, category);
         GetReservationsUseCase.Result result;


### PR DESCRIPTION
## 관련 이슈
- #244

## 해결 사항
- [x] Page를 PageModeled로 한번 래핑해서, 페이지네이션의 직렬화가 제대로 수행되도록 수정하였습니다.

## 수정 사항
### 반환되는 JSON 변경
```
        "page": {
            "size": 2,
            "number": 0,
            "totalElements": 2,
            "totalPages": 1
        }
``` 