### PR TITLE
[BE] 회원가입 api 호출시 RequestDTO로 역직렬화 안되는 버그 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/exchanges/SignUpRequestDto.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/exchanges/SignUpRequestDto.java
@@ -1,6 +1,8 @@
 package com.ddbb.dingdong.presentation.endpoint.auth.exchanges;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 public class SignUpRequestDto {
@@ -11,6 +13,8 @@ public class SignUpRequestDto {
     private Long schoolId;
 
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Home {
         private Double houseLatitude;
         private Double houseLongitude;

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/exchanges/SignUpRequestDto.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/auth/exchanges/SignUpRequestDto.java
@@ -1,6 +1,5 @@
 package com.ddbb.dingdong.presentation.endpoint.auth.exchanges;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
@@ -12,7 +11,6 @@ public class SignUpRequestDto {
     private Long schoolId;
 
     @Data
-    @AllArgsConstructor
     public static class Home {
         private Double houseLatitude;
         private Double houseLongitude;


### PR DESCRIPTION
## 관련 이슈
- [x] #246 

## 버그 원인
### 기존 코드
```java
@Data
public class SignUpRequestDto {
    private String name;
    private String email;
    private String password;
    private Home home;
    private Long schoolId;

    @Data
    @AllArgsConstructor
    public static class Home {
        private Double houseLatitude;
        private Double houseLongitude;
        private String houseRoadNameAddress;
    }
}
``` 

기존 코드에서는 `@AllArgsConstructor` 어노테이션을 붙이는데,
이렇게되면 기본 생성자가 사라져서 Jackson의 역 직렬화가 실패합니다.

### 수정된 코드
```java
@Data
public class SignUpRequestDto {
    private String name;
    private String email;
    private String password;
    private Home home;
    private Long schoolId;

    @Data
    @AllArgsConstructor
    @NoArgsConstructor
    public static class Home {
        private Double houseLatitude;
        private Double houseLongitude;
        private String houseRoadNameAddress;
    }
}
``` 

`@AllArgsConstructor`를 어드민 테스트기능에서 직접 사용하고있다고 하여, `@NoArgsConstructor`를 붙여서 임시로 해결하였습니다.
