### PR TITLE
[BE] 버스 이름 할당 방식 변경

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationsUseCase.java
@@ -55,7 +55,7 @@ public class GetReservationsUseCase implements UseCase<GetReservationsUseCase.Pa
                         operationInfo = new Result.ReservationInfo.OperationInfo(
                                 r.getBusScheduleId(),
                                 r.getBusStatus(),
-                                r.getBusName(),
+                                "버스 " + String.format("%02d", r.getBusId()),
                                 r.getBusStopArrivalTime()
                         );
                         expectedDepartureTime = r.getRealDepartureTime();

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetUserBusScheduleInfoUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetUserBusScheduleInfoUseCase.java
@@ -1,0 +1,72 @@
+package com.ddbb.dingdong.application.usecase.reservation;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.reservation.repository.ReservationQueryRepository;
+import com.ddbb.dingdong.domain.reservation.repository.projection.UserReservationProjection;
+import com.ddbb.dingdong.domain.reservation.service.ReservationErrors;
+import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserBusScheduleInfoUseCase implements UseCase<GetUserBusScheduleInfoUseCase.Param, GetUserBusScheduleInfoUseCase.Result> {
+    private final ReservationQueryRepository reservationQueryRepository;
+
+    @Override
+    public Result execute(Param param) {
+        return getUserBusScheduleInfo(param);
+    }
+
+    private Result getUserBusScheduleInfo(Param param) {
+        Long userId = param.getUserId();
+        Long busScheduleId = param.getBusScheduleId();
+        UserReservationProjection projection = reservationQueryRepository.queryReservationByBusScheduleIdAndUserId(userId, busScheduleId)
+                .orElseThrow(ReservationErrors.BUS_SCHEDULE_NOT_FOUND::toException);
+
+        return new Result(
+                projection.getReservationId(),
+                projection.getBusStopRoadNameAddress(),
+                projection.getDirection(),
+                projection.getExpectedArrivalTime(),
+                projection.getExpectedDepartureTime(),
+                new Result.OperationInfo(
+                        projection.getBusStatus(),
+                        projection.getBusName(),
+                        projection.getBusStopArrivalTime()
+                )
+        );
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private Long userId;
+        private Long busScheduleId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Result {
+        private Long reservationId;
+        private String busStopName;
+        private Direction direction;
+        private LocalDateTime expectedArrivalTime;
+        private LocalDateTime expectedDepartureTime;
+        private OperationInfo operationInfo;
+
+        @Getter
+        @AllArgsConstructor
+        public static class OperationInfo {
+            private OperationStatus busStatus;
+            private String busName;
+            private LocalDateTime busStopArrivalTime;
+        }
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetUserBusScheduleInfoUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetUserBusScheduleInfoUseCase.java
@@ -38,7 +38,7 @@ public class GetUserBusScheduleInfoUseCase implements UseCase<GetUserBusSchedule
                 projection.getExpectedDepartureTime(),
                 new Result.OperationInfo(
                         projection.getBusStatus(),
-                        projection.getBusName(),
+                        "버스 " + String.format("%02d", projection.getBusId()),
                         projection.getBusStopArrivalTime()
                 )
         );

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -22,7 +22,7 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
            bs_arrival.arrivalTime AS realArrivalTime,
            r.status AS reservationStatus,
            bs_arrival.id AS busScheduleId,
-           b.name AS busName,
+           b.id AS busId,
            bs_arrival.status AS busStatus,
            bs.roadNameAddress AS busStopRoadNameAddress,
            bs.expectedArrivalTime AS busStopArrivalTime
@@ -87,7 +87,7 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
            bs_arrival.arrivalTime AS realArrivalTime,
            t.reservation.status AS reservationStatus,
            bs_arrival.id AS busScheduleId,
-           bs_arrival.bus.name AS busName,
+           bs_arrival.bus.id AS busId,
            bs_arrival.status AS busStatus,
            bs.roadNameAddress AS busStopRoadNameAddress,
            bs.expectedArrivalTime AS busStopArrivalTime

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/projection/UserReservationProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/projection/UserReservationProjection.java
@@ -20,6 +20,6 @@ public interface UserReservationProjection {
     ReservationStatus getReservationStatus();
     Long getBusScheduleId();
     OperationStatus getBusStatus();
-    String getBusName();
+    Long getBusId();
     LocalDateTime getBusStopArrivalTime();
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusScheduleManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusScheduleManagement.java
@@ -32,8 +32,7 @@ public class BusScheduleManagement {
         BusSchedule busSchedule = new BusSchedule();
         busSchedule.setPath(path);
         busSchedule.setSchoolId(schoolId);
-        //TODO 버스할당 ->추후 수정
-        busSchedule.setBus(new Bus("버스 01"));
+        busSchedule.setBus(new Bus("가상 버스"));
         if(direction.equals(Direction.TO_SCHOOL)) {
             busSchedule.setArrivalTime(dingdongTime);
         } else {

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/ReservationController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/ReservationController.java
@@ -29,6 +29,7 @@ public class ReservationController {
     private final MakeTogetherReservationUseCase makeTogetherReservationUseCase;
     private final CancelReservationUseCase cancelReservationUseCase;
     private final SuggestReservationUseCase suggestReservationUseCase;
+    private final GetUserBusScheduleInfoUseCase getUserBusScheduleInfoUseCase;
 
     @GetMapping
     public ResponseEntity<GetReservationsUseCase.Result> getReservations(
@@ -186,5 +187,25 @@ public class ReservationController {
         }
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/busSchedules/{busScheduleId}")
+    public ResponseEntity<GetUserBusScheduleInfoUseCase.Result> getUserBusScheduleInfo(
+            @LoginUser AuthUser user,
+            @PathVariable Long busScheduleId
+    ) {
+        Long userId = user.id();
+        GetUserBusScheduleInfoUseCase.Param param = new GetUserBusScheduleInfoUseCase.Param(
+                userId,
+                busScheduleId
+        );
+        GetUserBusScheduleInfoUseCase.Result result;
+        try {
+            result = getUserBusScheduleInfoUseCase.execute(param);
+        } catch (DomainException ex) {
+            throw new APIException(ex, HttpStatus.NOT_FOUND);
+        }
+
+        return ResponseEntity.ok().body(result);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- [x] #266 

## 구현 내용
- 기존 Bus 테이블의 필드인 name을 가지고 버스이름을 그대로 보여주었는데, primary key를 활용하여 버스 01, 버스 02 등으로 이름을 만들어서 반환하도록 변경하였습니다.
- 기존 Bus 테이블의 Name은 모두 "가상 버스" 로 통일합니다.