### PR TITLE
[BE] 웹 소켓 구독 버그 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StopBusUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StopBusUseCase.java
@@ -4,6 +4,7 @@ import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
 import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
 import com.ddbb.dingdong.domain.transportation.service.BusScheduleManagement;
+import com.ddbb.dingdong.infrastructure.bus.simulator.BusSubscriptionLockManager;
 import com.ddbb.dingdong.infrastructure.bus.simulator.subscription.BusSubscriptionManager;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,11 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class StopBusUseCase implements UseCase<StopBusUseCase.Param, Void> {
     private final BusSubscriptionManager subscriptionManager;
     private final BusScheduleManagement busScheduleManagement;
+    private final BusSubscriptionLockManager busSubscriptionLockManager;
     @Override
     @Transactional
     public Void execute(Param param) {
         busScheduleManagement.updateBusSchedule(param.busScheduleId, OperationStatus.ENDED);
         subscriptionManager.cleanPublisher(param.busScheduleId);
+        busSubscriptionLockManager.removeLock(param.busScheduleId);
         return null;
     }
 

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/routing/CreateRouteUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/routing/CreateRouteUseCase.java
@@ -14,6 +14,7 @@ import com.ddbb.dingdong.domain.transportation.entity.Path;
 import com.ddbb.dingdong.domain.transportation.service.BusScheduleManagement;
 import com.ddbb.dingdong.domain.user.entity.School;
 import com.ddbb.dingdong.domain.user.service.UserManagement;
+import com.ddbb.dingdong.infrastructure.bus.simulator.BusSubscriptionLockManager;
 import com.ddbb.dingdong.infrastructure.routing.BusRouteCreationService;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,6 +32,7 @@ public class CreateRouteUseCase implements UseCase<CreateRouteUseCase.Param, Voi
     private final ClusteringService clusteringService;
     private final BusScheduleManagement busScheduleManagement;
     private final BusRouteCreationService busRouteCreationService;
+    private final BusSubscriptionLockManager busSubscriptionLockManager;
     private final UserManagement userManagement;
 
     @Transactional
@@ -94,6 +96,7 @@ public class CreateRouteUseCase implements UseCase<CreateRouteUseCase.Param, Voi
             ticket.setBusStopId(busStop.getId());
             reservationManagement.allocate(reservation,ticket);
         }
+        busSubscriptionLockManager.addLock(busSchedule.getId());
     }
 
     @Getter

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusErrors.java
@@ -10,7 +10,10 @@ public enum BusErrors implements ErrorInfo {
     NO_BUS_FOUND("조건에 만족하는 버스가 존재하지 않습니다."),
     NO_BUS_STOP("조건에 맞는 버스 정류장이 없습니다."),
     NO_SEATS("남은 좌석이 없습니다."),
-    BUS_SCHEDULE_UPDATE_ERR("버스 운행 상태 업데이트 도중 오류가 발생했습니다.")
+    BUS_SCHEDULE_UPDATE_ERROR("버스 운행 상태 업데이트 도중 오류가 발생했습니다."),
+    STOP_BUS_ERROR("버스 운행 종료 도중 문제가 발생했습니다."),
+    BUS_NOT_INITIATED("버스의 운행 준비가 끝나지 않았습니다."),
+    BUS_ALREADY_STOPPED("버스 운행이 종료되었습니다.")
     ;
     private final String desc;
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusErrors.java
@@ -13,7 +13,10 @@ public enum BusErrors implements ErrorInfo {
     BUS_SCHEDULE_UPDATE_ERROR("버스 운행 상태 업데이트 도중 오류가 발생했습니다."),
     STOP_BUS_ERROR("버스 운행 종료 도중 문제가 발생했습니다."),
     BUS_NOT_INITIATED("버스의 운행 준비가 끝나지 않았습니다."),
-    BUS_ALREADY_STOPPED("버스 운행이 종료되었습니다.")
+    BUS_ALREADY_STOPPED("버스 운행이 종료되었습니다."),
+    BUS_SUBSCRIBE_ERROR("버스 구독 도중에 문제가 발생했습니다."),
+    BUS_START_ERROR("버스 운행 시작 도중에 문제가 발생했습니다."),
+    BUS_UNSUBSCRIBE_ERROR("버스 구독 취소 도중에 문제가 발생했습니다."),
     ;
     private final String desc;
 

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/simulator/BusSubscriptionLockManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/simulator/BusSubscriptionLockManager.java
@@ -1,0 +1,26 @@
+package com.ddbb.dingdong.infrastructure.bus.simulator;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.StampedLock;
+
+@Component
+public class BusSubscriptionLockManager {
+    private final Map<Long, StampedLock> locks = new ConcurrentHashMap<>();
+
+    public Optional<StampedLock> getLock(long busScheduleId) {
+        StampedLock stampedLock = locks.get(busScheduleId);
+        return Optional.ofNullable(stampedLock);
+    }
+
+    public void addLock(long busScheduleId) {
+        locks.computeIfAbsent(busScheduleId, id -> new StampedLock());
+    }
+
+    public void removeLock(long busScheduleId) {
+        locks.remove(busScheduleId);
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/simulator/BusSubscriptionLockManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/simulator/BusSubscriptionLockManager.java
@@ -1,23 +1,24 @@
 package com.ddbb.dingdong.infrastructure.bus.simulator;
 
-import org.springframework.stereotype.Component;
+
+import com.ddbb.dingdong.infrastructure.bus.simulator.subscription.StoppableLock;
+import org.springframework.stereotype.Service;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.StampedLock;
 
-@Component
+@Service
 public class BusSubscriptionLockManager {
-    private final Map<Long, StampedLock> locks = new ConcurrentHashMap<>();
+    private final Map<Long, StoppableLock> locks = new ConcurrentHashMap<>();
 
-    public Optional<StampedLock> getLock(long busScheduleId) {
-        StampedLock stampedLock = locks.get(busScheduleId);
+    public Optional<StoppableLock> getLock(long busScheduleId) {
+        StoppableLock stampedLock = locks.get(busScheduleId);
         return Optional.ofNullable(stampedLock);
     }
 
     public void addLock(long busScheduleId) {
-        locks.computeIfAbsent(busScheduleId, id -> new StampedLock());
+        locks.computeIfAbsent(busScheduleId, id -> new StoppableLock());
     }
 
     public void removeLock(long busScheduleId) {

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/simulator/subscription/StoppableLock.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/simulator/subscription/StoppableLock.java
@@ -1,0 +1,57 @@
+package com.ddbb.dingdong.infrastructure.bus.simulator.subscription;
+
+import com.ddbb.dingdong.domain.common.exception.DomainException;
+import com.ddbb.dingdong.domain.transportation.service.BusErrors;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Slf4j
+public class StoppableLock {
+    private static final long BUSY_WAIT_INTERVAL_MILLIS = 100L;
+    private final ReentrantLock lock = new ReentrantLock(true);
+    private final AtomicBoolean isStopped = new AtomicBoolean(false);
+
+    /**
+     * 이미 stop된 상태라면 바로 false를 반환하고,
+     * lock을 얻고 stop 된 상태라면 바로 lock을 반납하고 false를 반환합니다.
+     * true를 반환하면 외부에서 반드시 unlock을 해야합니다.
+     * **/
+    public boolean lock() {
+        if (isStopped.get()) {
+            return false;
+        }
+        lock.lock();
+        if (isStopped.get()) {
+            lock.unlock();
+            return false;
+        }
+        return true;
+    }
+
+    public void unlock() {
+        if (lock.isHeldByCurrentThread()) {
+            lock.unlock();
+        }
+    }
+
+    public void stopAndWait() {
+        isStopped.set(true);
+        while (lock.hasQueuedThreads()) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(BUSY_WAIT_INTERVAL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.debug(e.getMessage());
+                throw new DomainException(BusErrors.STOP_BUS_ERROR);
+            }
+        }
+    }
+
+    public boolean isStopped() {
+        return isStopped.get();
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/simulator/subscription/subscriber/CancelableSubscriber.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/simulator/subscription/subscriber/CancelableSubscriber.java
@@ -6,6 +6,8 @@ public abstract class CancelableSubscriber<T> implements Flow.Subscriber<T> {
     protected Flow.Subscription subscription;
 
     public void cancel() {
-        this.subscription.cancel();
+        if (subscription != null) {
+            this.subscription.cancel();
+        }
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/notification/WebPushNotificationEventListener.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/notification/WebPushNotificationEventListener.java
@@ -35,11 +35,5 @@ public class WebPushNotificationEventListener {
     @Async
     @EventListener
     protected void sendBusStartNotification(BusDepartureEvent event) {
-        NotificationMessage message = messageFormatter.busDeparture(event.getArrivalTime(), LocalDateTime.now());
-        List<Long> userIds = event.getUserReservationIds()
-                .stream()
-                .map(UserBusStopTime.UserReservationId::userId)
-                .toList();
-        notificationSender.send(message.title(), message.content(), userIds);
     }
 }

--- a/backend/src/test/java/com/ddbb/dingdong/bus/BusSimulatorTest.java
+++ b/backend/src/test/java/com/ddbb/dingdong/bus/BusSimulatorTest.java
@@ -1,5 +1,6 @@
 package com.ddbb.dingdong.bus;
 
+import com.ddbb.dingdong.infrastructure.bus.simulator.BusSubscriptionLockManager;
 import com.ddbb.dingdong.infrastructure.bus.simulator.subscription.BusSubscriptionManager;
 import com.ddbb.dingdong.infrastructure.bus.simulator.subscription.UserSubscription;
 import com.ddbb.dingdong.domain.transportation.service.BusPublishService;
@@ -19,7 +20,7 @@ class BusSimulatorTest {
 
     public BusSimulatorTest() {
         this.segmentProvider = new TMapStubRouteSegmentProvider();
-        this.manager = new BusSubscriptionManager();
+        this.manager = new BusSubscriptionManager(new BusSubscriptionLockManager());
         this.factory = new BusSimulatorFactory(segmentProvider);
         this.publishService = new BusPublishService(this.factory, manager);
     }


### PR DESCRIPTION
## 관련 이슈
- #155 
- #26 

## 버그 원인
-  구독 취소 시 발행자가 없는 구독자가 구독 해제할 때 subscription이 null 인 경우 NullPointerException을 던지고 lock을 해제하지 않은 채 종료 됨

## 개선 사항
- Map에서 락을 제거하기 전에 락 상태를 업데이트하고, 락에 대기 중인 모든 스레드들이 종료되길 기다렸다가 락을 제거함
- 명시적인 락 관리자를 도입하여 구독자가 락을 만들면서 진입하지 않도록 함
- 명시적으로 try-catch-finally 문을 도입하여 예상치 못한 예외에도 반드시 락을 풀도록 함
