### PR TITLE
[BE] 함께타기 요청/결제 시, 48시간 내외임을 검증하던 로직 제거 및 알람 버그 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/ApplicationInitializer.java
+++ b/backend/src/main/java/com/ddbb/dingdong/ApplicationInitializer.java
@@ -52,7 +52,7 @@ public class ApplicationInitializer {
     private void adminSignUp() {
         Home home = new Home(null, 37.5143, 127.0294, 37.513716, 127.029790, "에티버스" ,"학동로 180");
         Timetable timetable = new Timetable();
-        User user = new User(null, "admin", "admin@admin.com", "abcd1234!@", Role.ADMIN, LocalDateTime.now(), school, null, timetable);
+        User user = new User(null, "admin", "admin@admin.com", passwordEncoder.encode("abcd1234!@"), Role.ADMIN, LocalDateTime.now(), school, null, timetable);
         user.associateHome(home);
         user = userRepository.save(user);
         Wallet wallet = new Wallet(null, user.getId(), 1000000, LocalDateTime.now(), new ArrayList<>());

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
@@ -88,6 +88,10 @@ public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReser
         BusStop busStop = busStopRepository.findById(busStopId)
                 .orElseThrow(ReservationErrors.BUS_STOP_NOT_FOUND::toException);
 
+        if(busStop.getLocationId() == null) {
+            throw ReservationErrors.INVALID_BUS_STOP.toException();
+        }
+
         Long queryBusScheduleId = busStop.getPath().getBusSchedule().getId();
 
         if (!busScheduleId.equals(queryBusScheduleId)) {

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
@@ -52,7 +52,9 @@ public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReser
     private void checkHasDuplicatedReservation(Param param) {
         Long userId = param.getReservationInfo().userId;
         LocalDateTime hopeTime = extractTimeFromBusSchedule(param);
-
+        if(hopeTime.isBefore(LocalDateTime.now())) {
+            throw ReservationErrors.EXPIRED_RESERVATION_DATE.toException();
+        }
         reservationManagement.checkHasDuplicatedReservation(userId, hopeTime);
     }
 
@@ -97,6 +99,7 @@ public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReser
         if (!busScheduleId.equals(queryBusScheduleId)) {
             throw ReservationErrors.INVALID_BUS_SCHEDULE.toException();
         }
+
 
         Reservation reservation = makeReservation(busSchedule, userId);
         Ticket ticket = new Ticket(null, busScheduleId, busStopId, reservation);

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
@@ -3,9 +3,11 @@ package com.ddbb.dingdong.application.usecase.reservation;
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.reservation.repository.BusStopRepository;
 import com.ddbb.dingdong.domain.reservation.service.ReservationErrors;
 import com.ddbb.dingdong.domain.reservation.service.ReservationManagement;
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
+import com.ddbb.dingdong.domain.transportation.entity.BusStop;
 import com.ddbb.dingdong.domain.transportation.repository.BusScheduleRepository;
 import com.ddbb.dingdong.infrastructure.auth.encrypt.TokenManager;
 import lombok.AllArgsConstructor;
@@ -21,6 +23,7 @@ public class RequestTogetherReservationUseCase implements UseCase<RequestTogethe
     private final TokenManager tokenManager;
     private final BusScheduleRepository busScheduleRepository;
     private final ReservationManagement reservationManagement;
+    private final BusStopRepository busStopRepository;
 
     @Override
     public Result execute(Param param) {
@@ -40,7 +43,12 @@ public class RequestTogetherReservationUseCase implements UseCase<RequestTogethe
 
     private LocalDateTime extractTimeFromBusSchedule(Param param) {
         Long busScheduleId = param.busScheduleId;
+        Long busStopId = param.getBusStopId();
         BusSchedule schedule = busScheduleRepository.findById(busScheduleId).orElseThrow(ReservationErrors.BUS_SCHEDULE_NOT_FOUND::toException);
+        BusStop busStop = busStopRepository.findById(busStopId).orElseThrow(ReservationErrors.BUS_STOP_NOT_FOUND::toException);
+        if(busStop.getLocationId() == null) {
+            throw ReservationErrors.INVALID_BUS_STOP.toException();
+        }
         LocalDateTime hopeTime = schedule.getDirection().equals(Direction.TO_SCHOOL)
                 ? schedule.getArrivalTime()
                 : schedule.getDepartureTime();

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
@@ -52,6 +52,11 @@ public class RequestTogetherReservationUseCase implements UseCase<RequestTogethe
         LocalDateTime hopeTime = schedule.getDirection().equals(Direction.TO_SCHOOL)
                 ? schedule.getArrivalTime()
                 : schedule.getDepartureTime();
+
+        if(hopeTime.isBefore(LocalDateTime.now())) {
+            throw ReservationErrors.EXPIRED_RESERVATION_DATE.toException();
+        }
+
         return hopeTime;
     }
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/NotificationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/repository/NotificationQueryRepository.java
@@ -27,10 +27,12 @@ public interface NotificationQueryRepository extends JpaRepository<Notification,
         r.startDate AS startDate,
         CASE
             WHEN n.type = 'BUS_START' THEN bs.expectedArrivalTime
+            WHEN r.direction = 'TO_HOME' THEN r.departureTime
             ELSE l.expectedArrivalTime
         END AS expectedStartTime,
         CASE
             WHEN n.type = 'BUS_START' THEN busSchedule.arrivalTime
+            WHEN r.direction = 'TO_HOME' THEN l.expectedArrivalTime
             ELSE r.arrivalTime
         END AS expectedEndTime
     FROM Notification n

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationManagement.java
@@ -105,33 +105,6 @@ public class ReservationManagement {
         }
     }
 
-    public void validateTogetherReservationDate(LocalDateTime reservationDate , Direction direction) {
-
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime startDate = reservationDate.minusHours(48);
-        LocalDateTime deadLine = reservationDate;
-
-        if(now.isBefore(startDate)){
-            throw ReservationErrors.BEFORE_RESERVATION_DATE.toException();
-        }
-        if(now.isAfter(deadLine)){
-            throw ReservationErrors.EXCEEDED_RESERVATION_DATE.toException();
-        }
-        if(reservationDate.getMinute() != 0 && reservationDate.getMinute() != 30) {
-            throw ReservationErrors.NOT_SUPPORTED_RESERVATION_TIME.toException();
-        }
-        if(direction.equals(Direction.TO_SCHOOL)) {
-            if (reservationDate.toLocalTime().isBefore(LocalTime.of(8,0)) || reservationDate.toLocalTime().isAfter(LocalTime.of(18,0))) {
-                throw ReservationErrors.NOT_SUPPORTED_RESERVATION_TIME.toException();
-            }
-        } else {
-            if (reservationDate.toLocalTime().isBefore(LocalTime.of(11,0)) || reservationDate.toLocalTime().isAfter(LocalTime.of(21,0))) {
-                throw ReservationErrors.NOT_SUPPORTED_RESERVATION_TIME.toException();
-            }
-        }
-
-    }
-
     public List<LocalDateTime> recommendReservationDates(YearMonth yearMonth, Direction direction, Timetable timetable) {
         return IntStream.rangeClosed(1, yearMonth.lengthOfMonth())
                 .mapToObj(yearMonth::atDay)
@@ -196,7 +169,6 @@ public class ReservationManagement {
     }
 
     private Reservation reserveTogether(Reservation reservation) {
-        validateTogetherReservation(reservation);
         return reservationRepository.save(reservation);
     }
 
@@ -206,15 +178,6 @@ public class ReservationManagement {
         }
         LocalDateTime reservationDate = reservation.getDirection().equals(Direction.TO_SCHOOL) ? reservation.getArrivalTime() : reservation.getDepartureTime();
         validateGeneralReservationDate(reservationDate , reservation.getDirection());
-    }
-
-    private void validateTogetherReservation(Reservation reservation) {
-        if (!ReservationType.TOGETHER.equals(reservation.getType())) {
-            throw ReservationErrors.INVALID_RESERVATION_TYPE.toException();
-        } else if (!ReservationStatus.ALLOCATED.equals(reservation.getStatus())) {
-            throw ReservationErrors.INVALID_RESERVATION_STATUS.toException();
-        }
-        validateTogetherReservationDate(reservation.getArrivalTime(), reservation.getDirection());
     }
 
 


### PR DESCRIPTION
## 관련 이슈
- [x] #275 
- [x] #277 
## 변경 내용
- [x] 함께타기 도메인 로직에서, 48시간 내의 버스 스케쥴인지를 검증하던 로직을 삭제하였습니다.
- [x] 추가로, 현재 시간이 해당 버스 스케쥴의 딩동타임보다 지났을때, 예약을 하지못하게 예외처리를 하였습니다. (READY상태에서 출발안하고 방치된 경우.. 를 대비해서?)
- [x] 알람 조회 JpaQueryRepository에서 TO_HOME 에대한 분기처리 해주어 알람 조회 버그 수정
