### PR TITLE
[BE] 함께 타기 예매 시도 시, 누락된 필드에 대한 Null check 검사 기능 구현

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
@@ -2,6 +2,7 @@ package com.ddbb.dingdong.application.usecase.reservation;
 
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.application.usecase.reservation.error.ReservationInvalidParamErrors;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.reservation.repository.BusStopRepository;
 import com.ddbb.dingdong.domain.reservation.service.ReservationErrors;
@@ -27,6 +28,7 @@ public class RequestTogetherReservationUseCase implements UseCase<RequestTogethe
 
     @Override
     public Result execute(Param param) {
+        param.validate();
         LocalDateTime hopeTime = extractTimeFromBusSchedule(param);
         checkHasDuplicatedReservation(param.userId, hopeTime);
         String token = generateToken(param);
@@ -66,6 +68,16 @@ public class RequestTogetherReservationUseCase implements UseCase<RequestTogethe
         private Long userId;
         private Long busStopId;
         private Long busScheduleId;
+
+        @Override
+        public boolean validate() {
+            if (busStopId != null) {
+                throw ReservationInvalidParamErrors.INVALID_BUS_STOP_ID.toException();
+            } else if (busScheduleId != null) {
+                throw ReservationInvalidParamErrors.INVALID_BUS_SCHEDULE_ID.toException();
+            }
+            return true;
+        }
     }
 
     @Getter

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
@@ -71,9 +71,9 @@ public class RequestTogetherReservationUseCase implements UseCase<RequestTogethe
 
         @Override
         public boolean validate() {
-            if (busStopId != null) {
+            if (busStopId == null) {
                 throw ReservationInvalidParamErrors.INVALID_BUS_STOP_ID.toException();
-            } else if (busScheduleId != null) {
+            } else if (busScheduleId == null) {
                 throw ReservationInvalidParamErrors.INVALID_BUS_SCHEDULE_ID.toException();
             }
             return true;

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/error/ReservationInvalidParamErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/error/ReservationInvalidParamErrors.java
@@ -4,6 +4,8 @@ import com.ddbb.dingdong.application.exception.InvalidParamErrorInfo;
 
 public enum ReservationInvalidParamErrors implements InvalidParamErrorInfo {
     DUPLICATED_DATES("중복된 예약시간이 입력되었습니다.","date"),
+    INVALID_BUS_STOP_ID("버스 정류장 ID가 유효하지 않습니다.", "busStopId"),
+    INVALID_BUS_SCHEDULE_ID("버스 스케쥴 ID가 유효하지 않습니다.", "busScheduleId"),
     ;
 
     private final String desc;


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- [ ] #282 
## 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- [x] 함께 타기 예매 필드 누락으로 생기는 NullPointerException 오류를 사전에 검증하여 Server Error가 아닌 Client Error(400)으로 처리하도록 수정 

## 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->