### PR TITLE
[BE] 버스 스케쥴 조회 시 개인이 탈 수 있는 기록이 존재할 경우만 조회하도록 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetAvailableBusLine.java
@@ -55,7 +55,7 @@ public class GetAvailableBusLine implements UseCase<GetAvailableBusLine.Param, G
                     .longitude(busStop.getLongitude())
                     .build();
             Response.BusInfo busInfo = Response.BusInfo.builder()
-                    .name(busStop.getBusName())
+                    .name(String.format("버스 %02d", busStop.getBusId()))
                     .reservedSeat(count)
                     .totalSeat(15)
                     .build();

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -46,7 +46,7 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
             OR
             (:category = 5 AND CAST(r.status AS STRING) = 'CANCELED')
             OR
-            (:category = 6 AND (CAST(r.status AS STRING) = 'ALLOCATED' OR CAST(r.status AS STRING) = 'PENDING'))
+            (:category = 6 AND (CAST(r.status AS STRING) = 'ALLOCATED' OR CAST(r.status AS STRING) = 'PENDING') AND CAST(bs_arrival.status AS STRING) != 'ENDED')
         )
     ORDER BY
        CASE WHEN :sort = 0 THEN r.startDate END DESC,

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Repository
 public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
     @Query("SELECT bst.id as busStopId, bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
-            "bst.expectedArrivalTime as busStopTime, b.name as busName, bs.id as busScheduleId " +
+            "bst.expectedArrivalTime as busStopTime, b.id as busId, bs.id as busScheduleId " +
             "FROM BusStop bst " +
             "JOIN Ticket t ON t.busStopId = bst.id " +
             "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
@@ -1,5 +1,6 @@
 package com.ddbb.dingdong.domain.transportation.repository;
 
+import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.transportation.entity.BusStop;
 import com.ddbb.dingdong.domain.transportation.repository.projection.AvailableBusStopProjection;
 import com.ddbb.dingdong.domain.transportation.repository.projection.UserIdAndReservationIdProjection;
@@ -19,23 +20,14 @@ public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
             "JOIN Ticket t ON t.busStopId = bst.id " +
             "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
             "JOIN Bus b ON b.id = bs.bus.id " +
-            "WHERE bs.departureTime = :departureTime AND bs.schoolId = :schoolId " +
-            "AND bs.status = 'READY'")
-    List<AvailableBusStopProjection> findAvailableGoHomeBusStop(
-            @Param("departureTime") LocalDateTime departureTime,
-            @Param("schoolId") Long schoolId
-    );
-
-    @Query("SELECT bst.id as busStopId, bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
-            "bst.expectedArrivalTime as busStopTime, b.name as busName, bs.id as busScheduleId " +
-            "FROM BusStop bst " +
-            "JOIN Ticket t ON t.busStopId = bst.id " +
-            "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
-            "JOIN Bus b ON b.id = bs.bus.id " +
-            "WHERE bs.arrivalTime = :arrivalTime AND bs.schoolId = :schoolId " +
-            "AND bs.status = 'READY'")
-    List<AvailableBusStopProjection> findAvailableGoSchoolBusStop(
-            @Param("arrivalTime") LocalDateTime arrivalTime,
+            "WHERE ((:direction = 'GO_HOME' AND bs.departureTime = :time) OR " +
+            "       (:direction = 'GO_SCHOOL' AND bs.arrivalTime = :time)) " +
+            "AND bs.schoolId = :schoolId " +
+            "AND bs.status = 'READY'"
+    )
+    List<AvailableBusStopProjection> findAvailableBusStop(
+            @Param("direction") Direction direction,
+            @Param("time") LocalDateTime time,
             @Param("schoolId") Long schoolId
     );
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
@@ -21,10 +21,11 @@ public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
             "JOIN Ticket t ON t.busStopId = bst.id " +
             "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
             "JOIN Bus b ON b.id = bs.bus.id " +
-            "WHERE ((:direction = 'GO_HOME' AND bs.departureTime = :time) OR " +
-            "       (:direction = 'GO_SCHOOL' AND bs.arrivalTime = :time)) " +
+            "WHERE ((bs.direction = 'TO_HOME' AND bs.departureTime = :time) OR " +
+                "(bs.direction = 'TO_SCHOOL' AND bs.arrivalTime = :time)) " +
             "AND bs.schoolId = :schoolId " +
-            "AND bs.status = 'READY'"
+            "AND bs.status = 'READY'" +
+            "AND bs.direction = :direction"
     )
     List<AvailableBusStopProjection> findAvailableBusStop(
             @Param("direction") Direction direction,
@@ -35,17 +36,14 @@ public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
 
     @Query("SELECT bst.latitude as latitude, bst.longitude as longitude, " +
             "busSchedule.id as busScheduleId, " +
-            "CASE WHEN busSchedule.direction = 'TO_SCHOOL' " +
-                "THEN busSchedule.arrivalTime " +
-                "ELSE busSchedule.departureTime " +
-            "END AS busScheduleTime " +
+            "CASE WHEN busSchedule.direction = com.ddbb.dingdong.domain.reservation.entity.vo.Direction.TO_SCHOOL " +
+            "THEN busSchedule.arrivalTime ELSE busSchedule.departureTime END AS busScheduleTime " +
             "FROM BusStop bst " +
             "JOIN Ticket t ON t.busStopId = bst.id " +
             "JOIN BusSchedule busSchedule ON t.busScheduleId = busSchedule.id " +
             "WHERE busSchedule.direction = :direction " +
             "AND busSchedule.schoolId = :schoolId " +
-            "AND busSchedule.status = 'READY'"
-    )
+            "AND busSchedule.status = 'READY'")
     List<AllAvailableBusStopProjection> findAllAvailableBusStop(
             @Param("direction") Direction direction,
             @Param("schoolId") Long schoolId

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Repository
 public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
     @Query("SELECT bst.id as busStopId, bst.roadNameAddress as busStopName, bst.latitude as latitude, bst.longitude as longitude, " +
-            "bst.expectedArrivalTime as busStopTime, b.id as busId, bs.id as busScheduleId " +
+            "bst.expectedArrivalTime as busStopTime, b.id as busId, bs.id as busScheduleId, bst.locationId as locationId " +
             "FROM BusStop bst " +
             "JOIN Ticket t ON t.busStopId = bst.id " +
             "JOIN BusSchedule bs ON t.busScheduleId = bs.id " +
@@ -37,7 +37,8 @@ public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
     @Query("SELECT bst.latitude as latitude, bst.longitude as longitude, " +
             "busSchedule.id as busScheduleId, " +
             "CASE WHEN busSchedule.direction = com.ddbb.dingdong.domain.reservation.entity.vo.Direction.TO_SCHOOL " +
-            "THEN busSchedule.arrivalTime ELSE busSchedule.departureTime END AS busScheduleTime " +
+            "THEN busSchedule.arrivalTime ELSE busSchedule.departureTime END AS busScheduleTime, " +
+            "bst.locationId as locationId " +
             "FROM BusStop bst " +
             "JOIN Ticket t ON t.busStopId = bst.id " +
             "JOIN BusSchedule busSchedule ON t.busScheduleId = busSchedule.id " +

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusStopQueryRepository.java
@@ -2,6 +2,7 @@ package com.ddbb.dingdong.domain.transportation.repository;
 
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.transportation.entity.BusStop;
+import com.ddbb.dingdong.domain.transportation.repository.projection.AllAvailableBusStopProjection;
 import com.ddbb.dingdong.domain.transportation.repository.projection.AvailableBusStopProjection;
 import com.ddbb.dingdong.domain.transportation.repository.projection.UserIdAndReservationIdProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -28,6 +29,25 @@ public interface BusStopQueryRepository extends JpaRepository<BusStop, Long> {
     List<AvailableBusStopProjection> findAvailableBusStop(
             @Param("direction") Direction direction,
             @Param("time") LocalDateTime time,
+            @Param("schoolId") Long schoolId
+    );
+
+
+    @Query("SELECT bst.latitude as latitude, bst.longitude as longitude, " +
+            "busSchedule.id as busScheduleId, " +
+            "CASE WHEN busSchedule.direction = 'TO_SCHOOL' " +
+                "THEN busSchedule.arrivalTime " +
+                "ELSE busSchedule.departureTime " +
+            "END AS busScheduleTime " +
+            "FROM BusStop bst " +
+            "JOIN Ticket t ON t.busStopId = bst.id " +
+            "JOIN BusSchedule busSchedule ON t.busScheduleId = busSchedule.id " +
+            "WHERE busSchedule.direction = :direction " +
+            "AND busSchedule.schoolId = :schoolId " +
+            "AND busSchedule.status = 'READY'"
+    )
+    List<AllAvailableBusStopProjection> findAllAvailableBusStop(
+            @Param("direction") Direction direction,
             @Param("schoolId") Long schoolId
     );
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AllAvailableBusStopProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AllAvailableBusStopProjection.java
@@ -6,5 +6,6 @@ public interface AllAvailableBusStopProjection {
     Double getLongitude();
     Double getLatitude();
     Long getBusScheduleId();
+    Long getLocationId();
     LocalDateTime getBusScheduleTime();
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AllAvailableBusStopProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AllAvailableBusStopProjection.java
@@ -1,0 +1,10 @@
+package com.ddbb.dingdong.domain.transportation.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface AllAvailableBusStopProjection {
+    Double getLongitude();
+    Double getLatitude();
+    Long getBusScheduleId();
+    LocalDateTime getBusScheduleTime();
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
@@ -10,4 +10,5 @@ public interface AvailableBusStopProjection {
     Double getLatitude();
     Long getBusId();
     Long getBusScheduleId();
+    Long getLocationId();
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/projection/AvailableBusStopProjection.java
@@ -8,6 +8,6 @@ public interface AvailableBusStopProjection {
     String getBusStopName();
     Double getLongitude();
     Double getLatitude();
-    String getBusName();
+    Long getBusId();
     Long getBusScheduleId();
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
@@ -7,12 +7,11 @@ import java.util.Optional;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import com.ddbb.dingdong.domain.transportation.repository.projection.AllAvailableBusStopProjection;
-
 import org.springframework.stereotype.Service;
 
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.transportation.repository.BusStopQueryRepository;
+import com.ddbb.dingdong.domain.transportation.repository.projection.AllAvailableBusStopProjection;
 import com.ddbb.dingdong.domain.transportation.repository.projection.AvailableBusStopProjection;
 import com.ddbb.dingdong.util.GeoUtil;
 
@@ -23,7 +22,12 @@ import lombok.RequiredArgsConstructor;
 public class BusStopQueryService {
     private static final int THRESHOLD_METER = 1000;
 
-    public record AvailableBusStopDistance(AvailableBusStopProjection busStop, double distance) {
+    public record AvailableBusStopDistance(AvailableBusStopProjection busStop, double distance)
+    implements Comparable<AvailableBusStopDistance> {
+        @Override
+        public int compareTo(AvailableBusStopDistance o) {
+            return Double.compare(distance, o.distance);
+        }
     }
 
     public record AvailableBusStopWithTimeDistance(AllAvailableBusStopProjection busStop, double distance) {

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
@@ -35,10 +35,9 @@ public class BusStopQueryService {
     public List<AvailableBusStopProjection> findAvailableBusStops(
             Long schoolId, Direction direction, LocalDateTime time, Double longitude, Double latitude
     ) {
-        List<AvailableBusStopProjection> projections = switch (direction) {
-            case TO_HOME -> busStopQueryRepository.findAvailableGoHomeBusStop(time, schoolId);
-            case TO_SCHOOL -> busStopQueryRepository.findAvailableGoSchoolBusStop(time, schoolId);
-        };
+        List<AvailableBusStopProjection> projections = busStopQueryRepository.findAvailableBusStop(
+                direction, time, schoolId
+        );
         return projections.stream()
             .map(projection -> {
                 double distance = GeoUtil.haversine(latitude, longitude, projection.getLatitude(), projection.getLongitude());

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusStopQueryService.java
@@ -42,6 +42,7 @@ public class BusStopQueryService {
                 direction, time, schoolId
         );
         return projections.stream()
+                .filter(projection -> projection.getLocationId() != null)
                 .map(projection -> {
                     double distance = GeoUtil.haversine(latitude, longitude, projection.getLatitude(), projection.getLongitude());
                     return new AvailableBusStopDistance(projection, distance);
@@ -63,6 +64,7 @@ public class BusStopQueryService {
     ) {
         List<AllAvailableBusStopProjection> items = busStopQueryRepository.findAllAvailableBusStop(direction, schoolId);
         return items.stream()
+                .filter(projection -> projection.getLocationId() != null)
                 .filter(item -> {
                     double distance = GeoUtil.haversine(latitude, longitude, item.getLatitude(), item.getLongitude());
                     return distance <= THRESHOLD_METER;

--- a/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/user/repository/UserQueryRepository.java
@@ -19,9 +19,6 @@ public interface UserQueryRepository extends JpaRepository<User, Long> {
             "FROM User u JOIN u.home h WHERE u.id = :userId")
     Optional<HomeLocationProjection> queryHomeLocationByUserId(@Param("userId") Long userId);
 
-    @Query("SELECT u.school.id as schoolId FROM User u WHERE u.id = :userId")
-    Optional<SchoolIdProjection> findSchoolIDByUserId(@Param("userId") Long userId);
-
     @Query("SELECT u.school.id as schoolId, u.home.stationLatitude as stationLatitude, u.home.stationLongitude as stationLongitude " +
             "FROM User u " +
             "WHERE u.id = :userId")


### PR DESCRIPTION
### 관련 이슈
- #262 

### 구현 사항
1. 정말로 탑승 가능한 시간대만 조회하도록 탑승 가능 시간대 조회 API 변경
2. 버스 이름을 알맞은 형식에 맞게 응답하도록 수정
3. 운행 종료된 예매의 경우 보여지지 않도록 변경