### PR TITLE
[BE] 예매내역 조회에서 카테고리가 HOME일때, PENDING상태인 예매를 못 가져오는 버그 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -46,7 +46,7 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
             OR
             (:category = 5 AND CAST(r.status AS STRING) = 'CANCELED')
             OR
-            (:category = 6 AND (CAST(r.status AS STRING) = 'ALLOCATED' OR CAST(r.status AS STRING) = 'PENDING') AND CAST(bs_arrival.status AS STRING) != 'ENDED')
+            (:category = 6 AND ((CAST(r.status AS STRING) = 'ALLOCATED' AND CAST(bs_arrival.status AS STRING) != 'ENDED')OR CAST(r.status AS STRING) = 'PENDING'))
         )
     ORDER BY
        CASE WHEN :sort = 0 THEN r.startDate END DESC,


### PR DESCRIPTION
## 해결 사항
- [x] 예매내역 조회에서 카테고리가 HOME일때, PENDING상태인 예매를 못 가져오고 ALLOCATED만 가져오는 버그를 수정하였습니다