### PR TITLE
[BE] 첫 가입 딩동머니 충전 내역을 히스토리 테이블에 자동 추가하도록 변경

### DIFF
--- a/backend/.database/schema.sql
+++ b/backend/.database/schema.sql
@@ -182,7 +182,7 @@ CREATE TABLE IF NOT EXISTS dingdong_money_usage_history (
                                                             refunded_reservation_id BIGINT,
                                                             time_stamp DATETIME(6) NOT NULL,
                                                             wallet_id BIGINT,
-                                                            type ENUM('FREE_CHARGE','PAY','REFUND') NOT NULL,
+                                                            type ENUM('WELCOME_MONEY_CHARGE','FREE_CHARGE','PAY','REFUND') NOT NULL,
                                                             PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 ALTER TABLE dingdong_money_usage_history ADD CONSTRAINT FK_money_usage_wallet FOREIGN KEY (wallet_id) REFERENCES wallet(id);

--- a/backend/src/main/java/com/ddbb/dingdong/ApplicationInitializer.java
+++ b/backend/src/main/java/com/ddbb/dingdong/ApplicationInitializer.java
@@ -60,7 +60,7 @@ public class ApplicationInitializer {
                 notification.setUserId((long)(i + 1));
                 notification.setReservationId(null);
                 notification.setType(NotificationType.WELCOME);
-                notification.setMoney(10000);
+                notification.setMoney(30000);
 
                 notificationRepository.save(notification);
             }

--- a/backend/src/main/java/com/ddbb/dingdong/ApplicationInitializer.java
+++ b/backend/src/main/java/com/ddbb/dingdong/ApplicationInitializer.java
@@ -1,5 +1,10 @@
 package com.ddbb.dingdong;
 
+import com.ddbb.dingdong.application.usecase.auth.SignUpUseCase;
+import com.ddbb.dingdong.domain.notification.entity.Notification;
+import com.ddbb.dingdong.domain.notification.entity.vo.NotificationType;
+import com.ddbb.dingdong.domain.notification.repository.NotificationRepository;
+import com.ddbb.dingdong.domain.notification.service.NotificationEventListener;
 import com.ddbb.dingdong.domain.payment.entity.Wallet;
 import com.ddbb.dingdong.domain.payment.repository.WalletRepository;
 import com.ddbb.dingdong.domain.user.entity.Home;
@@ -10,10 +15,12 @@ import com.ddbb.dingdong.domain.user.entity.vo.Role;
 import com.ddbb.dingdong.domain.user.repository.SchoolRepository;
 import com.ddbb.dingdong.domain.user.repository.UserRepository;
 import com.ddbb.dingdong.infrastructure.auth.encrypt.PasswordEncoder;
+import com.ddbb.dingdong.presentation.endpoint.auth.exchanges.SignUpRequestDto;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -26,8 +33,12 @@ public class ApplicationInitializer {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final WalletRepository walletRepository;
+    private final SignUpUseCase signUpUseCase;
     private static final String adminEmail = "admin@admin.com";
     private static School school;
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
     @PostConstruct
     public void init() {
 
@@ -45,6 +56,13 @@ public class ApplicationInitializer {
 
             for (int i = 0 ; i < 30; i++) {
                 autoSignUp(i, password);
+                Notification notification = new Notification();
+                notification.setUserId((long)(i + 1));
+                notification.setReservationId(null);
+                notification.setType(NotificationType.WELCOME);
+                notification.setMoney(10000);
+
+                notificationRepository.save(notification);
             }
         }
     }
@@ -59,14 +77,28 @@ public class ApplicationInitializer {
         walletRepository.save(wallet);
     }
 
-    private void autoSignUp(int testId, String password) {
-        Home home = new Home(null, 37.5143, 127.0294, 37.513716, 127.029790, "에티버스" ,"학동로 180");
+    public void autoSignUp(int testId, String password) {
+
+//        Home home = new Home(null, 37.5143, 127.0294, 37.513716, 127.029790, "에티버스" ,"학동로 180");
         String email = testId == 0 ? "test@test.com" : "test" +testId + "@test.com";
-        Timetable timetable = new Timetable();
-        User user = new User(null, "test", email, password, Role.USER, LocalDateTime.now(), school, null,timetable);
-        user.associateHome(home);
-        user = userRepository.save(user);
-        Wallet wallet = new Wallet(null, user.getId(), 50000, LocalDateTime.now(), new ArrayList<>());
-        walletRepository.save(wallet);
+        signUpUseCase.execute(
+                new SignUpUseCase.Param(
+                    "테스트계정",
+                        email,
+                        "Abcd1234!@",
+                        new SignUpRequestDto.Home(
+                                37.5143,
+                                127.0294,
+                                "학동로 171"
+                        ),
+                        1L
+                )
+        );
+//        Timetable timetable = new Timetable();
+//        User user = new User(null, "test", email, password, Role.USER, LocalDateTime.now(), school, null,timetable);
+//        user.associateHome(home);
+//        user = userRepository.save(user);
+//        Wallet wallet = new Wallet(null, user.getId(), 50000, LocalDateTime.now(), new ArrayList<>());
+//        walletRepository.save(wallet);
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/auth/service/AuthManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/auth/service/AuthManagement.java
@@ -33,7 +33,7 @@ public class AuthManagement {
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
 
-    private static final int WELCOME_MONEY = 50000;
+    private static final int WELCOME_MONEY = 30000;
 
     public User signUp(String name, String email, String password, SignUpRequestDto.Home home, Long schoolId) {
         School school = schoolRepository.findById(schoolId).orElseThrow(AuthErrors.SCHOOL_NOT_FOUND::toException);
@@ -57,7 +57,11 @@ public class AuthManagement {
                 .timetable(timetable)
                 .build();
         user = userRepository.save(user);
-        Wallet wallet = new Wallet(null, user.getId(), WELCOME_MONEY, LocalDateTime.now(), new ArrayList<>());
+
+        Wallet wallet = new Wallet();
+        wallet.setUserId(user.getId());
+        wallet.welcomeMoneyCharge(WELCOME_MONEY);
+
         walletRepository.save(wallet);
 
         eventPublisher.publishEvent(new SignUpSuccessEvent(user.getId()));

--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
@@ -27,7 +27,7 @@ public class NotificationEventListener {
     private final NotificationManagement notificationManagement;
     private final SocketRepository socketRepository;
     private static final int TICKET_PRICE = 1000;
-    private static final int WELCOME_MONEY = 10000;
+    private static final int WELCOME_MONEY = 30000;
     private static final String ALARM_SOCKET_MSG = "alarm";
     private final BusStopQueryRepository busStopQueryRepository;
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/payment/entity/Wallet.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/payment/entity/Wallet.java
@@ -26,7 +26,7 @@ public class Wallet {
     private Long userId;
 
     @Column(nullable = false)
-    private Integer balance;
+    private int balance;
 
     @Column(nullable = false)
     private LocalDateTime lastUpdatedAt = LocalDateTime.now();
@@ -58,6 +58,13 @@ public class Wallet {
         this.balance += chargePrice;
         lastUpdatedAt = LocalDateTime.now();
         DingdongMoneyUsageHistory history = generateHistory(DingdongMoneyUsageType.FREE_CHARGE, chargePrice, null);
+        this.usageHistory.add(history);
+    }
+
+    public void welcomeMoneyCharge(int chargePrice) {
+        this.balance += chargePrice;
+        lastUpdatedAt = LocalDateTime.now();
+        DingdongMoneyUsageHistory history = generateHistory(DingdongMoneyUsageType.WELCOME_MONEY_CHARGE, chargePrice, null);
         this.usageHistory.add(history);
     }
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/payment/entity/vo/DingdongMoneyUsageType.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/payment/entity/vo/DingdongMoneyUsageType.java
@@ -3,6 +3,7 @@ package com.ddbb.dingdong.domain.payment.entity.vo;
 public enum DingdongMoneyUsageType {
     PAY,
     FREE_CHARGE,
+    WELCOME_MONEY_CHARGE,
     REFUND,
     ;
 }


### PR DESCRIPTION
## 관련 이슈
- [x] #294 

## 구현 사항
- notification type에 'WELCOME_MONEY_CHARGE' 타입 추가
- 첫 가입 딩동머니를 5만원에서 3만원으로 수정 (너무 과한거같아서 30일치만 ..)
- initializer에서 usecase를 호출하도록 코드 수정 -> 시연용 테스트계정 비밀번호를 Abcd1234!@로 변경 (맨앞에 대문자로 수정)
- 가입시 자동으로 dingdong money history table에 3만원 추가되었다는 내역을 저장