### PR TITLE
[BE] 버스 정류장 추천 시 예약한 시간을 제외하는 조건 추가

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetBusSchedulesUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/GetBusSchedulesUseCase.java
@@ -3,6 +3,7 @@ package com.ddbb.dingdong.application.usecase.bus;
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.reservation.repository.ReservationQueryRepository;
 import com.ddbb.dingdong.domain.transportation.repository.BusScheduleQueryRepository;
 import com.ddbb.dingdong.domain.transportation.repository.projection.ScheduleTimeProjection;
 import com.ddbb.dingdong.domain.transportation.service.BusStopQueryService;
@@ -17,23 +18,28 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 @Service
 @RequiredArgsConstructor
 public class GetBusSchedulesUseCase implements UseCase<GetBusSchedulesUseCase.Param, GetBusSchedulesUseCase.Response> {
     private final UserQueryRepository userRepository;
     private final BusStopQueryService busStopQueryService;
+    private final ReservationQueryRepository reservationQueryRepository;
 
     @Override
     @Transactional(readOnly = true)
     public Response execute(Param param) {
         HomeStationProjection proj = userRepository.findHomeStationLocationWithSchoolId(param.getUserId())
                 .orElseThrow(UserErrors.NOT_FOUND::toException);
+        Set<LocalDateTime> reserved = new TreeSet<>(reservationQueryRepository.findReservedTimeByUserId(param.getUserId()));
         List<LocalDateTime> times = busStopQueryService.findAllAvailableBusStopTimes(
                 param.direction,
                 proj.getSchoolId(),
                 proj.getStationLongitude(),
-                proj.getStationLatitude()
+                proj.getStationLatitude(),
+                reserved
         );
         return new Response(times);
     }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ReservationQueryRepository extends JpaRepository<Reservation, Long> {
@@ -98,4 +101,15 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
         AND t.reservation.status = 'ALLOCATED' AND (bs_arrival.status = 'RUNNING' OR bs_arrival.status = 'READY')
     """)
     Optional<UserReservationProjection> queryReservationByBusScheduleIdAndUserId(@Param("userId") Long userId, @Param("busScheduleId") Long busScheduleId);
+
+    @Query("""
+        SELECT DISTINCT
+                CASE
+                    WHEN r.direction = 'TO_SCHOOL' THEN r.arrivalTime
+                    ELSE r.departureTime
+                END AS reservedTime
+            FROM Reservation r
+            WHERE r.status != 'CANCELED'
+    """)
+    List<LocalDateTime> findReservedTimeByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 관련 이슈
- #293 

## 구현 사항
- 예약 내역에서 취소 되지 않은 예매 내역의 딩동 타임을 조회하고, 이 조회한 내역을 바탕으로 겹치는 시간을 필터링합니다.
- 버스 시간대 조회, 버스 정류장 조회 모두 적용했습니다.