### PR TITLE
[BE] 중복 예약된 예약 건수에 대한 자세한 알림 메시지

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeGeneralReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeGeneralReservationUseCase.java
@@ -57,11 +57,12 @@ public class MakeGeneralReservationUseCase implements UseCase<MakeGeneralReserva
 
     private void checkHasDuplicatedReservation(Param param) {
         Long userId = param.reservationInfo.userId;
-        List<Param.ReservationInfo.ReservationDate> hopeTimes = param.reservationInfo.reservationDates;
+        List<LocalDateTime> hopeTimes = param.reservationInfo.reservationDates
+                .stream()
+                .map(Param.ReservationInfo.ReservationDate::getDate)
+                .toList();
 
-        for (Param.ReservationInfo.ReservationDate hopeTime : hopeTimes) {
-            reservationManagement.checkHasDuplicatedReservation(userId, hopeTime.date);
-        }
+        reservationManagement.checkHasDuplicatedReservations(userId, hopeTimes);
     }
 
     private void reserve(Param param) {

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestGeneralReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestGeneralReservationUseCase.java
@@ -43,10 +43,12 @@ public class RequestGeneralReservationUseCase implements UseCase<RequestGeneralR
 
     private void checkHasDuplicatedReservation(Param param) {
         Long userId = param.userId;
-        List<Param.ReservationInfo> hopeTimes = param.reservationDates;
-        for (RequestGeneralReservationUseCase.Param.ReservationInfo hopeTime : hopeTimes) {
-           reservationManagement.checkHasDuplicatedReservation(userId, hopeTime.date);
-        }
+        List<LocalDateTime> hopeTimes = param.reservationDates
+                .stream()
+                .map(reservationInfo -> reservationInfo.date)
+                .toList();
+
+        reservationManagement.checkHasDuplicatedReservations(userId, hopeTimes);
     }
 
     private void validateReservationDates(Param param) {

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -112,4 +112,18 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
             WHERE r.status != 'CANCELED'
     """)
     List<LocalDateTime> findReservedTimeByUserId(@Param("userId") Long userId);
+
+    @Query("""
+        SELECT DISTINCT
+            CASE WHEN r.direction = 'TO_SCHOOL' THEN r.arrivalTime
+                ELSE r.departureTime
+            END AS reserveTime
+        FROM Reservation r
+        WHERE r.userId = :userId
+        AND r.status != 'CANCELED'
+        AND (r.arrivalTime is not null and r.arrivalTime in :time) OR
+            (r.departureTime is not null and r.departureTime in :time)
+    """)
+    List<LocalDateTime> findDuplicatedReservationTime(@Param("userId") Long userId, @Param("time") List<LocalDateTime> times);
+
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/DuplicatedReservationError.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/DuplicatedReservationError.java
@@ -19,4 +19,9 @@ public class DuplicatedReservationError implements ErrorInfo {
         times.forEach(time -> desc.append(time).append("\n"));
         return desc.toString();
     }
+
+    @Override
+    public String getCode() {
+        return "ALREADY_HAS_SAME_RESERVATION";
+    }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/DuplicatedReservationError.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/DuplicatedReservationError.java
@@ -1,0 +1,22 @@
+package com.ddbb.dingdong.domain.reservation.service;
+
+import com.ddbb.dingdong.domain.common.exception.ErrorInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class DuplicatedReservationError implements ErrorInfo {
+    private List<LocalDateTime> times;
+
+    @Override
+    public String getDesc() {
+        StringBuilder desc = new StringBuilder();
+        desc.append("다음 시간대에 이미 예약이 존재합니다.\n");
+        times.forEach(time -> desc.append(time).append("\n"));
+        return desc.toString();
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationManagement.java
@@ -5,6 +5,7 @@ import com.ddbb.dingdong.domain.reservation.entity.Ticket;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationStatus;
 import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationType;
+import com.ddbb.dingdong.domain.reservation.repository.ReservationQueryRepository;
 import com.ddbb.dingdong.domain.reservation.repository.ReservationRepository;
 import com.ddbb.dingdong.domain.reservation.service.event.AllocationFailedEvent;
 import com.ddbb.dingdong.domain.reservation.service.event.AllocationSuccessEvent;
@@ -27,6 +28,7 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 public class ReservationManagement {
     private final ReservationRepository reservationRepository;
+    private final ReservationQueryRepository reservationQueryRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     public Reservation reserve(Reservation reservation) {
@@ -102,6 +104,13 @@ public class ReservationManagement {
     public void checkHasDuplicatedReservation(Long userId, LocalDateTime hopeTime) {
         if (reservationRepository.existsActiveReservation(hopeTime, userId)) {
             throw ReservationErrors.ALREADY_HAS_SAME_RESERVATION.toException();
+        }
+    }
+
+    public void checkHasDuplicatedReservations(Long userId, List<LocalDateTime> localDateTimes) {
+        List<LocalDateTime> duplicated = reservationQueryRepository.findDuplicatedReservationTime(userId, localDateTimes);
+        if (!duplicated.isEmpty()) {
+            throw new DuplicatedReservationError(duplicated).toException();
         }
     }
 


### PR DESCRIPTION
## 관련 이슈
- #302 

## 구현 사항
- 버스 예매하기 예매 정보 중에 어떤 날짜 때문에 겹치는 건지 명시적으로 알려주는 예외를 던지도록 변경

## 논의 사항
- 일단은 예외를 메시지로 전달하는데 프론트 분들과 소통 후 예외 메시지를 다르게 반환할 수 있음.