### PR TITLE
[fix] 이미 Path가 생성된 location은 클러스터 라벨을 "DONE"이라고 변경하기

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/clustering/CreateClusterUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/clustering/CreateClusterUseCase.java
@@ -46,6 +46,7 @@ public class CreateClusterUseCase implements UseCase<CreateClusterUseCase.Param,
     private void handleFail(List<Location> clusters) {
         for(Location location : clusters) {
             if(location.getClusterLabel() == null) {
+                location.setClusterLabel("FAILED");
                 reservationManagement.fail(location.getReservationId());
             }
         }

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/routing/CreateRouteUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/routing/CreateRouteUseCase.java
@@ -65,6 +65,7 @@ public class CreateRouteUseCase implements UseCase<CreateRouteUseCase.Param, Voi
         Map<Long, Long> allocatedReservation = new HashMap<>();
         Set<Long> locatedId = new HashSet<>();
         for(Location location : locations) {
+            location.setClusterLabel("DONE");
             locationMap.put(location.getId(), location);
             allocatedReservation.put(location.getReservationId(), location.getId());
             locatedId.add(location.getId());


### PR DESCRIPTION
## 문제 상황
- 같은 시간 & 방향의 버스를 여러번 배차할경우, 이전 클러스터라벨과 겹쳐서 에러가 발생합니다.
- 이미 생성된 location의 클러스터라벨을 "DONE"으로 명시적으로 변경해 해결하였습니다.