### PR TITLE
[BE] 일반예매시 중복 예약을 체크하는 쿼리에서, 괄호가 빠져서 다른 결과를 나왔던 버그 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -123,9 +123,8 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
         FROM Reservation r
         WHERE r.userId = :userId
         AND r.status != 'CANCELED'
-        AND (r.arrivalTime is not null and r.arrivalTime in :time) OR
-            (r.departureTime is not null and r.departureTime in :time)
+        AND ((r.arrivalTime is not null and r.arrivalTime in :time) OR
+            (r.departureTime is not null and r.departureTime in :time))
     """)
     List<LocalDateTime> findDuplicatedReservationTime(@Param("userId") Long userId, @Param("time") List<LocalDateTime> times);
-
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationRepository.java
@@ -23,4 +23,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     AND r.userId = :userId
     AND CAST(r.status AS STRING) IN ('PENDING', 'ALLOCATED')
     """)
-    boolean existsActiveReservation(@Param("time") LocalDateTime time, @Param("userId") Long userId);}
+    boolean existsActiveReservation(@Param("time") LocalDateTime time, @Param("userId") Long userId);
+}


### PR DESCRIPTION
## 증상
- 하교시, 다른 유저가 예매한 시간을 예매하면 중복되었다고 나오는 버그가 있었습니다.

## 원인
- 마지막 AND 쿼리를 크게 괄호로 묶었어야 했는데 빠져서 발생한 버그였습니다.

## 수정 후
<img width="580" alt="스크린샷 2025-02-21 오후 3 38 52" src="https://github.com/user-attachments/assets/c4a5d5c1-b3b6-422f-862a-fec8057bdc10" />
