### PR TITLE
[BE] reservationId로 단일 예매내역을 조회하는 API추가 

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/GetReservationUseCase.java
@@ -1,0 +1,95 @@
+package com.ddbb.dingdong.application.usecase.reservation;
+
+import com.ddbb.dingdong.application.common.Params;
+import com.ddbb.dingdong.application.common.UseCase;
+import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationStatus;
+import com.ddbb.dingdong.domain.reservation.repository.ReservationQueryRepository;
+import com.ddbb.dingdong.domain.reservation.repository.projection.UserReservationProjection;
+import com.ddbb.dingdong.domain.reservation.service.ReservationErrors;
+import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class GetReservationUseCase implements UseCase<GetReservationUseCase.Param, GetReservationUseCase.Result> {
+    private final ReservationQueryRepository reservationQueryRepository;
+
+    @Override
+    public Result execute(Param param) {
+        Long userId = param.userId;
+        Long reservationId = param.reservationId;
+
+        UserReservationProjection projection = reservationQueryRepository.queryReservationByReservationIdAndUserId(reservationId, userId)
+                .orElseThrow(ReservationErrors.NOT_FOUND::toException);
+
+        String busStopName = projection.getBusStopRoadNameAddress() == null ? projection.getUserHomeStationName() : projection.getBusStopRoadNameAddress();
+        LocalDateTime expectedArrivalTime = projection.getExpectedArrivalTime();
+        LocalDateTime expectedDepartureTime = projection.getExpectedDepartureTime();
+        Result.ReservationInfo.OperationInfo operationInfo = null;
+        if(ReservationStatus.ALLOCATED.equals(projection.getReservationStatus())) {
+             operationInfo = new Result.ReservationInfo.OperationInfo(
+                    projection.getBusScheduleId(),
+                     projection.getBusStatus(),
+                    "버스 " + String.format("%02d", projection.getBusId()),
+                    projection.getBusStopArrivalTime()
+            );
+            expectedDepartureTime = projection.getRealDepartureTime();
+            expectedArrivalTime = projection.getRealArrivalTime();
+        }
+
+        return new Result(
+                new Result.ReservationInfo(
+                        projection.getReservationId(),
+                        projection.getStartDate(),
+                        busStopName,
+                        projection.getDirection(),
+                        expectedArrivalTime,
+                        expectedDepartureTime,
+                        projection.getReservationStatus(),
+                        operationInfo
+                )
+        );
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Param implements Params {
+        private Long userId;
+        private Long reservationId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Result {
+        private ReservationInfo reservationInfo;
+
+        @Getter
+        @AllArgsConstructor
+        public static class ReservationInfo {
+            private Long reservationId;
+            private LocalDate startDate;
+            private String busStopName;
+            private Direction direction;
+            private LocalDateTime expectedArrivalTime;
+            private LocalDateTime expectedDepartureTime;
+            private ReservationStatus reservationStatus;
+            private OperationInfo operationInfo;
+
+            @Getter
+            @AllArgsConstructor
+            public static class OperationInfo {
+                private Long busScheduleId;
+                private OperationStatus busStatus;
+                private String busName;
+                private LocalDateTime busStopArrivalTime;
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/ReservationController.java
+++ b/backend/src/main/java/com/ddbb/dingdong/presentation/endpoint/reservation/ReservationController.java
@@ -10,6 +10,7 @@ import com.ddbb.dingdong.infrastructure.auth.security.annotation.LoginUser;
 import com.ddbb.dingdong.presentation.endpoint.reservation.exchanges.*;
 import com.ddbb.dingdong.presentation.endpoint.reservation.exchanges.enums.ReservationCategory;
 import com.ddbb.dingdong.presentation.endpoint.reservation.exchanges.enums.SortType;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +32,7 @@ public class ReservationController {
     private final CancelReservationUseCase cancelReservationUseCase;
     private final SuggestReservationUseCase suggestReservationUseCase;
     private final GetUserBusScheduleInfoUseCase getUserBusScheduleInfoUseCase;
+    private final GetReservationUseCase getReservationUseCase;
 
     @GetMapping
     public ResponseEntity<GetReservationsUseCase.Result> getReservations(
@@ -219,6 +221,23 @@ public class ReservationController {
         GetUserBusScheduleInfoUseCase.Result result;
         try {
             result = getUserBusScheduleInfoUseCase.execute(param);
+        } catch (DomainException ex) {
+            throw new APIException(ex, HttpStatus.NOT_FOUND);
+        }
+
+        return ResponseEntity.ok().body(result);
+    }
+
+    @GetMapping("/{reservationId}")
+    public ResponseEntity<GetReservationUseCase.Result> getReservationInfo(
+            @LoginUser AuthUser user,
+            @PathVariable Long reservationId
+    ) {
+        Long userId = user.id();
+        GetReservationUseCase.Param param = new GetReservationUseCase.Param(userId, reservationId);
+        GetReservationUseCase.Result result;
+        try {
+            result = getReservationUseCase.execute(param);
         } catch (DomainException ex) {
             throw new APIException(ex, HttpStatus.NOT_FOUND);
         }


### PR DESCRIPTION
## 구현사항
- [x] reservationId를 path variable로 전달하면, 단일 예매내역을 반환하는 API

## url
/api/users/reservations/:reservationId