### PR TITLE
[BE] 버스 출발 시 예매 아이디를 전송 로직 추가 #324

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
@@ -7,6 +7,7 @@ import com.ddbb.dingdong.domain.reservation.service.event.AllocationSuccessEvent
 import com.ddbb.dingdong.domain.transportation.repository.BusStopQueryRepository;
 import com.ddbb.dingdong.domain.transportation.repository.projection.UserIdAndReservationIdProjection;
 import com.ddbb.dingdong.domain.transportation.service.event.BusDepartureEvent;
+import com.ddbb.dingdong.infrastructure.webSocket.SocketMessageSender;
 import com.ddbb.dingdong.infrastructure.webSocket.repository.SocketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -25,7 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationEventListener {
     private final NotificationManagement notificationManagement;
-    private final SocketRepository socketRepository;
+    private final SocketMessageSender socketMessageSender;
     private static final int TICKET_PRICE = 1000;
     private static final int WELCOME_MONEY = 30000;
     private static final String ALARM_SOCKET_MSG = "alarm";
@@ -36,7 +37,7 @@ public class NotificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     protected void sendAllocationSuccessNotification(AllocationSuccessEvent event) {
         notificationManagement.sendNotification(NotificationType.ALLOCATION_SUCCESS, event.getUserId(), event.getReservationId(), null);
-        sendAlarm(event.getUserId());
+        socketMessageSender.sendMessage(event.getUserId(), ALARM_SOCKET_MSG);
     }
 
     @Async
@@ -44,7 +45,7 @@ public class NotificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     protected void sendAllocationFailNotification(AllocationFailedEvent event) {
         notificationManagement.sendNotification(NotificationType.ALLOCATION_FAILED, event.getUserId(), event.getReservationId(), TICKET_PRICE);
-        sendAlarm(event.getUserId());
+        socketMessageSender.sendMessage(event.getUserId(), ALARM_SOCKET_MSG);
     }
 
     @Async
@@ -52,7 +53,7 @@ public class NotificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     protected void sendWelcomeNotification(SignUpSuccessEvent event) {
         notificationManagement.sendNotification(NotificationType.WELCOME, event.getUserId(), null, WELCOME_MONEY);
-        sendAlarm(event.getUserId());
+        socketMessageSender.sendMessage(event.getUserId(), ALARM_SOCKET_MSG);
     }
 
     @Async
@@ -62,23 +63,9 @@ public class NotificationEventListener {
         List<UserIdAndReservationIdProjection> projections = busStopQueryRepository.queryUserIdByBusStops(event.getBusStopIds());
         for(UserIdAndReservationIdProjection projection : projections) {
             notificationManagement.sendNotification(NotificationType.BUS_START, projection.getUserId(), projection.getReservationId(), null);
-            sendAlarm(projection.getUserId());
-        }
-    }
-
-    private void sendAlarm(Long userId) {
-        WebSocketSession socket = socketRepository.get(userId);
-
-        if(socket != null && socket.isOpen()) {
-            int retryTimes = 0;
-            while (retryTimes < 3) {
-                try {
-                    socket.sendMessage(new TextMessage(ALARM_SOCKET_MSG));
-                    break;
-                } catch (IOException e) {
-                    retryTimes++;
-                }
-            }
+            socketMessageSender.sendMessage(
+                    projection.getUserId(), String.format(ALARM_SOCKET_MSG + "_%d", projection.getReservationId()), 3
+            );
         }
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/subscriber/SocketSubscriber.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/subscriber/SocketSubscriber.java
@@ -36,7 +36,7 @@ public class SocketSubscriber extends CancelableSubscriber<Point> {
     @Override
     public void onNext(Point item) {
         WebSocketSession webSocketSession = weakRef.get();
-        if (webSocketSession == null) {
+        if (webSocketSession == null || !webSocketSession.isOpen()) {
             this.busSubscriptionManager.unsubscribe(busId, userId);
             return ;
         }

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/SocketMessageSender.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/webSocket/SocketMessageSender.java
@@ -1,0 +1,39 @@
+package com.ddbb.dingdong.infrastructure.webSocket;
+
+import com.ddbb.dingdong.infrastructure.webSocket.repository.SocketRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SocketMessageSender {
+    private final SocketRepository socketRepository;
+
+    public boolean sendMessage(Long userId, String message) {
+        try {
+            WebSocketSession webSocketSession = socketRepository.get(userId);
+            if (webSocketSession != null && webSocketSession.isOpen()) {
+                webSocketSession.sendMessage(new TextMessage(message));
+            }
+            return true;
+        } catch (IOException e) {
+            log.info(e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean sendMessage(Long userId, String message, int retry) {
+        for (int i = 0; i < retry; i++) {
+            if (sendMessage(userId, message)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #324 

## 구현 사항
1. 버스 출발 시 예약 아이디를 전송하도록 NotificationEventListener의 구현을 변경했습니다.
2. 소켓 전송 로직을 담당하는 객체를 만들어 책임을 분리했습니다.
3. 구독자가 소켓전송 시 소켓이 닫혀있다면 전송을 하지 않도록 변경했습니다.