### PR TITLE
[BE] 함께 타기 예매에 대한 동시성 보장

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
@@ -9,12 +9,14 @@ import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
 import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationStatus;
 import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationType;
 import com.ddbb.dingdong.domain.reservation.repository.BusStopRepository;
+import com.ddbb.dingdong.domain.reservation.service.ReservationConcurrencyManager;
 import com.ddbb.dingdong.domain.reservation.service.ReservationErrors;
 import com.ddbb.dingdong.domain.reservation.service.ReservationManagement;
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
 import com.ddbb.dingdong.domain.transportation.entity.BusStop;
 import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
 import com.ddbb.dingdong.domain.transportation.repository.BusScheduleRepository;
+import com.ddbb.dingdong.domain.transportation.service.BusErrors;
 import com.ddbb.dingdong.infrastructure.auth.encrypt.token.TokenManager;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
@@ -28,6 +30,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReservationUseCase.Param, Void> {
     private final ReservationManagement reservationManagement;
+    private final ReservationConcurrencyManager reservationConcurrencyManager;
     private final PaymentManagement paymentManagement;
     private final BusStopRepository busStopRepository;
     private final TokenManager tokenManager;
@@ -80,34 +83,50 @@ public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReser
         Long busStopId = param.reservationInfo.getBusStopId();
         Long busScheduleId = param.reservationInfo.getBusScheduleId();
 
-        BusSchedule busSchedule = busScheduleRepository.findById(busScheduleId)
-                .orElseThrow(ReservationErrors.BUS_SCHEDULE_NOT_FOUND::toException);
+        reservationConcurrencyManager.lockBusSchedule(busScheduleId);
+        try {
+            Long cacheBusScheduleId = reservationConcurrencyManager.getUserInCache(userId);
+            if (cacheBusScheduleId == null) {
+                reservationConcurrencyManager.releaseSemaphore(busScheduleId);
+                throw ReservationErrors.EXCEEDED_RESERVATION_DEADLINE.toException();
+            } else if (!cacheBusScheduleId.equals(busScheduleId)) {
+                throw ReservationErrors.INVALID_ACCESS.toException();
+            }
 
-        if (!busSchedule.getStatus().equals(OperationStatus.READY)) {
-            throw ReservationErrors.EXCEEDED_RESERVATION_DATE.toException();
+            BusSchedule busSchedule = busScheduleRepository.findById(busScheduleId)
+                    .orElseThrow(ReservationErrors.BUS_SCHEDULE_NOT_FOUND::toException);
+
+            if (!busSchedule.getStatus().equals(OperationStatus.READY)) {
+                throw ReservationErrors.EXCEEDED_RESERVATION_DATE.toException();
+            }
+
+            BusStop busStop = busStopRepository.findById(busStopId)
+                    .orElseThrow(ReservationErrors.BUS_STOP_NOT_FOUND::toException);
+
+            if (busStop.getLocationId() == null) {
+                throw ReservationErrors.INVALID_BUS_STOP.toException();
+            }
+
+            Long queryBusScheduleId = busStop.getPath().getBusSchedule().getId();
+
+            if (!busScheduleId.equals(queryBusScheduleId)) {
+                throw ReservationErrors.INVALID_BUS_SCHEDULE.toException();
+            }
+
+
+            Reservation reservation = makeReservation(busSchedule, userId);
+            Ticket ticket = new Ticket(null, busScheduleId, busStopId, reservation);
+
+            reservation.issueTicket(ticket);
+            if (busScheduleRepository.issueTicket(busScheduleId) == 0) {
+                throw BusErrors.NO_SEATS.toException();
+            }
+
+            reservationManagement.reserve(reservation);
+        } finally {
+            reservationConcurrencyManager.removeUserInCache(userId);
+            reservationConcurrencyManager.unlockBusSchedule(busScheduleId);
         }
-
-        BusStop busStop = busStopRepository.findById(busStopId)
-                .orElseThrow(ReservationErrors.BUS_STOP_NOT_FOUND::toException);
-
-        if(busStop.getLocationId() == null) {
-            throw ReservationErrors.INVALID_BUS_STOP.toException();
-        }
-
-        Long queryBusScheduleId = busStop.getPath().getBusSchedule().getId();
-
-        if (!busScheduleId.equals(queryBusScheduleId)) {
-            throw ReservationErrors.INVALID_BUS_SCHEDULE.toException();
-        }
-
-
-        Reservation reservation = makeReservation(busSchedule, userId);
-        Ticket ticket = new Ticket(null, busScheduleId, busStopId, reservation);
-
-        reservation.issueTicket(ticket);
-        busSchedule.issue();
-
-        reservationManagement.reserve(reservation);
     }
 
     private Reservation makeReservation(BusSchedule busSchedule, Long userId) {

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/routing/CreateRouteUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/routing/CreateRouteUseCase.java
@@ -7,6 +7,7 @@ import com.ddbb.dingdong.domain.clustering.service.ClusteringService;
 import com.ddbb.dingdong.domain.reservation.entity.Reservation;
 import com.ddbb.dingdong.domain.reservation.entity.Ticket;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.reservation.service.ReservationConcurrencyManager;
 import com.ddbb.dingdong.domain.reservation.service.ReservationManagement;
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
 import com.ddbb.dingdong.domain.transportation.entity.BusStop;
@@ -15,6 +16,7 @@ import com.ddbb.dingdong.domain.transportation.service.BusScheduleManagement;
 import com.ddbb.dingdong.domain.user.entity.School;
 import com.ddbb.dingdong.domain.user.service.UserManagement;
 import com.ddbb.dingdong.infrastructure.bus.simulator.BusSubscriptionLockManager;
+import com.ddbb.dingdong.infrastructure.cache.SimpleCache;
 import com.ddbb.dingdong.infrastructure.routing.BusRouteCreationService;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,6 +31,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class CreateRouteUseCase implements UseCase<CreateRouteUseCase.Param, Void> {
     private final ReservationManagement reservationManagement;
+    private final ReservationConcurrencyManager reservationConcurrencyManager;
     private final ClusteringService clusteringService;
     private final BusScheduleManagement busScheduleManagement;
     private final BusRouteCreationService busRouteCreationService;
@@ -101,6 +104,7 @@ public class CreateRouteUseCase implements UseCase<CreateRouteUseCase.Param, Voi
             ticket.setBusStopId(busStop.getId());
             reservationManagement.allocate(reservation,ticket);
         }
+        reservationConcurrencyManager.initReservationData(busSchedule);
         busSubscriptionLockManager.addLock(busSchedule.getId());
     }
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationConcurrencyManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationConcurrencyManager.java
@@ -29,7 +29,7 @@ public class ReservationConcurrencyManager {
     }
 
     public void addUserToTimeLimitCache(Long userId, Long busScheduleId) {
-        cache.put(userId, busScheduleId, Duration.ofSeconds(EXPIRATION_TIME_MINUTES));
+        cache.put(userId, busScheduleId, Duration.ofMinutes(EXPIRATION_TIME_MINUTES));
     }
 
     public void acquireSemaphore(Long busScheduleId) {

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationConcurrencyManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationConcurrencyManager.java
@@ -1,0 +1,73 @@
+package com.ddbb.dingdong.domain.reservation.service;
+
+import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
+import com.ddbb.dingdong.domain.transportation.service.BusErrors;
+import com.ddbb.dingdong.infrastructure.cache.SimpleCache;
+import com.ddbb.dingdong.infrastructure.lock.ChannelLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationConcurrencyManager {
+    private final SimpleCache cache;
+
+    private enum Type { SEMAPHORE, LOCK };
+    private static final int EXPIRATION_TIME_MINUTES = 5;
+    private static final int EXPIRATION_TIME_DAYS = 2;
+
+    public void initReservationData(BusSchedule busSchedule) {
+        cache.put(Map.entry(busSchedule.getId(), Type.SEMAPHORE), new Semaphore(busSchedule.getRemainingSeats(), true), Duration.ofDays(EXPIRATION_TIME_DAYS));
+        cache.put(Map.entry(busSchedule.getId(), Type.LOCK), new ChannelLock(), Duration.ofDays(EXPIRATION_TIME_DAYS));
+    }
+
+    public void addUserToTimeLimitCache(Long userId, Long busScheduleId) {
+        cache.put(userId, busScheduleId, Duration.ofSeconds(EXPIRATION_TIME_MINUTES));
+    }
+
+    public void acquireSemaphore(Long busScheduleId) {
+        Semaphore semaphore = (Semaphore) cache.get(Map.entry(busScheduleId, Type.SEMAPHORE));
+        log.info("Acquired semaphore: {}", semaphore.availablePermits());
+        try {
+            if (!semaphore.tryAcquire(0, TimeUnit.SECONDS)) {
+                throw new InterruptedException();
+            }
+        } catch (InterruptedException e) {
+            throw BusErrors.NO_SEATS.toException();
+        }
+    }
+
+    public void releaseSemaphore(Long busScheduleId) {
+        Semaphore semaphore = (Semaphore) cache.get(Map.entry(busScheduleId, Type.SEMAPHORE));
+        semaphore.release();
+    }
+
+    public Long getUserInCache(Long userId) {
+        Object value = cache.get(userId);
+        if (value != null) return (Long) value;
+        return null;
+    }
+
+    public Long removeUserInCache(Long userId) {
+        Object value = cache.remove(userId);
+        if (value != null) return (Long) value;
+        return null;
+    }
+
+    public boolean lockBusSchedule(Long busScheduleId) {
+        ChannelLock lock = (ChannelLock) cache.get(Map.entry(busScheduleId, Type.LOCK));
+        return lock.entryLock();
+    }
+
+    public void unlockBusSchedule(Long busScheduleId) {
+        ChannelLock lock = (ChannelLock) cache.get(Map.entry(busScheduleId, Type.LOCK));
+        lock.unlock();
+    }
+}

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationErrors.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationErrors.java
@@ -11,6 +11,7 @@ public enum ReservationErrors implements ErrorInfo {
     EXCEEDED_RESERVATION_DATE("예약 가능 기간을 초과하였습니다."),
     BEFORE_RESERVATION_DATE("예약 가능 기간이 아닙니다."),
     NOT_SUPPORTED_RESERVATION_TIME("해당 예약 시간은 지원하지 않습니다"),
+    EXCEEDED_RESERVATION_DEADLINE("예약 가능한 시간이 지났습니다.."),
 
     INVALID_BUS_TICKET("유효하지 않은 버스 티켓입니다."),
     INVALID_BUS_STOP("유효하지 않은 버스 정류장입니다."),

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationManagement.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationManagement.java
@@ -3,7 +3,6 @@ package com.ddbb.dingdong.domain.reservation.service;
 import com.ddbb.dingdong.domain.reservation.entity.Reservation;
 import com.ddbb.dingdong.domain.reservation.entity.Ticket;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
-import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationStatus;
 import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationType;
 import com.ddbb.dingdong.domain.reservation.repository.ReservationQueryRepository;
 import com.ddbb.dingdong.domain.reservation.repository.ReservationRepository;

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleRepository.java
@@ -25,4 +25,8 @@ public interface BusScheduleRepository extends JpaRepository<BusSchedule, Long> 
             @Param("busScheduleId") Long busScheduleId,
             @Param("status") OperationStatus status
     );
+
+    @Modifying
+    @Query("UPDATE BusSchedule b SET b.remainingSeats = b.remainingSeats - 1 WHERE b.id = :busScheduleId AND b.remainingSeats > 0")
+    int issueTicket(@Param("busScheduleId") Long busScheduleId);
 }

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/cache/SimpleCache.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/cache/SimpleCache.java
@@ -6,10 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
@@ -25,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class SimpleCache  {
     private final Map<Object, CacheEntry> map = new HashMap<>();
-    public record CacheEntry(Object value, long expiryTimeMillis) { }
+    public record CacheEntry(Object value, long expiryTimeMillis, Runnable afterExpiryTask) {}
     private int RANDOM_SELECT_SIZE;
     @Value("${cache.cleanupIntervalMinutes:60}")
     private long cleanupIntervalMinutes;
@@ -51,7 +48,19 @@ public class SimpleCache  {
      */
     public void put(Object key, Object value, Duration ttl) {
         long expiryTime = System.currentTimeMillis() + ttl.toMillis();
-        map.put(key, new CacheEntry(value, expiryTime));
+        map.put(key, new CacheEntry(value, expiryTime, null));
+    }
+
+    /**
+     * 캐시에 키와 값, 만료 시 행동을 저장합니다.
+     * 지정된 TTL을 기준으로 만료 시간을 설정합니다.
+     * @param key   캐시 키
+     * @param value 캐시 값
+     * @param afterExpiryTask 만료 후 행동
+     */
+    public void put(Object key, Object value, Runnable afterExpiryTask, Duration ttl) {
+        long expiryTime = System.currentTimeMillis() + ttl.toMillis();
+        map.put(key, new CacheEntry(value, expiryTime, afterExpiryTask));
     }
 
     /**
@@ -61,7 +70,17 @@ public class SimpleCache  {
      */
     public void put(Object value, Duration ttl) {
         long expiryTime = System.currentTimeMillis() + ttl.toMillis();
-        map.put(value, new CacheEntry(value, expiryTime));
+        map.put(value, new CacheEntry(value, expiryTime, null));
+    }
+    /**
+     * 캐시에 값만 저장합니다.
+     * 지정된 TTL을 기준으로 만료 시간을 설정합니다.
+     * @param value 캐시 값
+     * @param afterExpiryTask 만료 후 행동
+     */
+    public void put(Object value, Runnable afterExpiryTask, Duration ttl) {
+        long expiryTime = System.currentTimeMillis() + ttl.toMillis();
+        map.put(value, new CacheEntry(value, expiryTime, afterExpiryTask));
     }
 
     /**
@@ -118,6 +137,7 @@ public class SimpleCache  {
             log.info(getRandomEntries().size() + " entries have been cleaned up in " + now + "ms");
             if (now >= entry.getValue().expiryTimeMillis) {
                 log.info("clean up cache");
+                if (entry.getValue().afterExpiryTask != null) entry.getValue().afterExpiryTask.run();
                 map.remove(entry.getKey());
             }
         }
@@ -131,11 +151,16 @@ public class SimpleCache  {
         }
         Object[] entryArray = map.entrySet().toArray();
         int sampleSize = Math.min(RANDOM_SELECT_SIZE, size);
-        for (int i = 0; i < sampleSize; i++) {
+        Set<Integer> selectedIndexes = new HashSet<>();
+
+        while (selectedIndexes.size() < sampleSize) {
             int randomIndex = ThreadLocalRandom.current().nextInt(entryArray.length);
-            @SuppressWarnings("unchecked")
-            Map.Entry<Object, CacheEntry> entry = (Map.Entry<Object, CacheEntry>) entryArray[randomIndex];
-            randomEntries.add(entry);
+            if (!selectedIndexes.contains(randomIndex)) {
+                selectedIndexes.add(randomIndex);
+                @SuppressWarnings("unchecked")
+                Map.Entry<Object, CacheEntry> entry = (Map.Entry<Object, CacheEntry>) entryArray[randomIndex];
+                randomEntries.add(entry);
+            }
         }
 
         return randomEntries;

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/cache/SimpleCache.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/cache/SimpleCache.java
@@ -34,7 +34,7 @@ public class SimpleCache  {
     public void init() {
         System.out.println(cleanupIntervalMinutes);
         Duration cleanupInterval = Duration.ofMinutes(cleanupIntervalMinutes);
-        this.RANDOM_SELECT_SIZE = 50;
+        this.RANDOM_SELECT_SIZE = 100;
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
         scheduler.scheduleAtFixedRate(
                 this::cleanUp,
@@ -74,7 +74,8 @@ public class SimpleCache  {
     public Object get(Object key) {
         CacheEntry entry = map.get(key);
         if (entry != null && System.currentTimeMillis() > entry.expiryTimeMillis) {
-            return map.remove(key).value;
+            map.remove(key);
+            return null;
         }
         return entry != null ? entry.value : null;
     }
@@ -92,6 +93,18 @@ public class SimpleCache  {
             map.remove(key);
         }
         return entry != null;
+    }
+
+    /**
+     * 캐시에서 키에 해당하는 값을 삭제합니다.
+     *
+     * @param key
+     * @return 키에 해당하는 값이 있다면 해당 값, 없다면 {@code null}을 반환합니다.
+     */
+    public Object remove(Object key) {
+        CacheEntry entry = map.remove(key);
+        if (entry != null) return entry.value;
+        return null;
     }
 
     /**

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -18,6 +18,9 @@ server:
         same-site: strict
         path: /
 
+cache:
+  cleanupIntervalMinutes: 5
+
 client:
   schema: ${CLIENT_SCHEMA}
   ip: ${CLIENT_ADDRESS}

--- a/backend/src/test/java/com/ddbb/dingdong/reservation/ReservationConcurrencyTest.java
+++ b/backend/src/test/java/com/ddbb/dingdong/reservation/ReservationConcurrencyTest.java
@@ -1,0 +1,88 @@
+package com.ddbb.dingdong.reservation;
+
+import com.ddbb.dingdong.application.usecase.reservation.MakeTogetherReservationUseCase;
+import com.ddbb.dingdong.application.usecase.reservation.RequestTogetherReservationUseCase;
+import com.ddbb.dingdong.domain.reservation.service.ReservationConcurrencyManager;
+import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
+import com.ddbb.dingdong.domain.transportation.repository.BusScheduleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class ReservationConcurrencyTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ReservationConcurrencyTest.class);
+    @Autowired
+    RequestTogetherReservationUseCase requestTogetherReservationUseCase;
+
+    @Autowired
+    MakeTogetherReservationUseCase makeTogetherReservationUseCase;
+
+    @Autowired
+    BusScheduleRepository busScheduleRepository;
+
+    private static final int MAX_USERS = 99;
+    private static final int MAX_SUCCESS = 15;
+    private final ExecutorService executor = Executors.newFixedThreadPool(MAX_USERS);
+    @Autowired
+    private ReservationConcurrencyManager reservationConcurrencyManager;
+
+
+    @Test
+    @DisplayName("100명 예매 동시성 실험")
+    public void test() throws InterruptedException {
+        AtomicInteger success = new AtomicInteger(1);
+        AtomicInteger fail = new AtomicInteger(0);
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        BusSchedule busSchedule = busScheduleRepository.findById(1L).get();
+        reservationConcurrencyManager.initReservationData(busSchedule);
+
+        for (int i = 2; i <= MAX_USERS; i++) {
+            int finalI = i;
+            executor.submit(() -> {
+                try {
+                    countDownLatch.await();
+                    RequestTogetherReservationUseCase.Result result = requestTogetherReservationUseCase.execute(new RequestTogetherReservationUseCase.Param((long) finalI, 1L, 1L));
+                    Thread.sleep(new Random().nextInt(10)*1000);
+                    makeTogetherReservationUseCase.execute(new MakeTogetherReservationUseCase.Param(
+                            result.getToken(),
+                            new MakeTogetherReservationUseCase.Param.ReservationInfo(
+                                    (long) finalI, 1L, 1L)
+                            )
+                    );
+                    success.incrementAndGet();
+                    makeTogetherReservationUseCase.execute(new MakeTogetherReservationUseCase.Param(
+                                    result.getToken(),
+                                    new MakeTogetherReservationUseCase.Param.ReservationInfo(
+                                            (long) finalI, 1L, 1L)
+                            )
+                    );
+                    success.incrementAndGet();
+                } catch (Exception e) {
+                    log.error("User ID: {} | {}", finalI, e.getMessage());
+                    fail.incrementAndGet();
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        countDownLatch.countDown();
+        Thread.sleep(15000);
+
+        assertEquals(MAX_SUCCESS, success.get());
+        assertEquals(MAX_USERS - 1, fail.get());
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,57 @@
+spring:
+    datasource:
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        url: jdbc:mysql://localhost:3306/dingdong?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+        username: root
+        password: 1234
+        hikari:
+            maximum-pool-size: 100 # 최대 DB Connection Pool 크기
+            minimum-idle: 100  # 최소 유휴 커넥션
+            idle-timeout: 30000  # 커넥션이 유휴 상태로 유지될 최대 시간(ms)
+            max-lifetime: 1800000  # 커넥션의 최대 생명주기(ms)
+            connection-timeout: 30000  # 커넥션을 얻기 위한 최대 대기 시간(ms)
+            keepalive-time: 150000
+    jpa:
+        database-platform: org.hibernate.dialect.MySQL8Dialect
+        hibernate:
+            ddl-auto: update
+        show-sql: false
+
+server:
+    servlet:
+        session:
+            cookie:
+                domain: ${CLIENT_ADDRESS}
+                same-site: strict
+                path: /
+
+cache:
+    cleanupIntervalMinutes: 5
+
+client:
+    schema: ${CLIENT_SCHEMA}
+    ip: ${CLIENT_ADDRESS}
+    port: ${CLIENT_PORT}
+
+api:
+    tmap:
+        base-url: https://apis.openapi.sk.com/tmap
+        endpoint:
+            route-optimization-20: /routes/routeOptimization20
+        apikeys:
+            - ${API_KEY_1}
+            - ${API_KEY_2}
+            - ${API_KEY_3}
+
+fcm:
+    renotify: ${FCM_RENOTIFIY}
+    silent: ${FCM_SILENT}
+    requireInteraction: ${FCM_REQUIRE_INTERACTION}
+    link: ${FCM_TOUCH_LINK}
+
+logging:
+    level:
+        org.hibernate.resource.transaction: OFF
+        org.hibernate.engine.transaction: OFF
+        org.springframework.transaction: OFF
+        org.springframework.orm.jpa: OFF


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- [x] #330 

## 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- [x] 함께 타기에 대한 동시성을 보장하도록 수정했습니다.
- [x] DB Lock을 걸지 않는 방향으로 수정했습니다.
1. SimpleCache를 이용하여, CreateRouteUseCase를 실행할 때 생성되는 BusSchedule의 id를 통해 남은 좌석수를 크기로 가지는 Semaphore와 Lock을 저장하도록 구현했습니다. (함께타기는 예매가 48시간 동안만 이루어지므로, 만료 기간을 2일로 설정)
2. 예매를 시도하는 사용자는 SimpleCache에 Key=userId, Value=busScheduleId, 만료기간=5분을 가지는 CacheEntry로 저장됩니다.
    - 1번 스케쥴을 예매 신청을 하고, 2번 스케쥴에 결제를 시도하는 행위를 막기 위해 Value에 busScheduleId를 설정했습니다.
3. 예매 시도 시, 중복 예매와 유효하지 않은 입력 값 검증이 끝난 후에 실질적으로 예매를 들어가는 부분부터 Semaphore를 얻도록 구현했습니다.
    - 만료 기간이 지났거나, SimpleCache에 의해 자동으로 Clean up되는 경우 세마포어를 반환하도록 했습니다.
4. 결제 시도 시, Bus Schedule 별로 관리되는 Lock을 얻어 실질적인 에매 확정 작업을 지은 후, Lock을 unlock하도록 구현했습니다.

## 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. 함께타기 예매 동시성 테스트
<img width="416" alt="스크린샷 2025-02-22 오후 8 46 10" src="https://github.com/user-attachments/assets/e0b505a0-9cea-491c-8010-82155a0a07d7" />

2. SimpleCache CleanUp 작업 시, 세마포어 반환 테스트
<img width="418" alt="스크린샷 2025-02-22 오후 10 46 53" src="https://github.com/user-attachments/assets/d0ac3a3b-62c9-41da-aae2-2e25cf70b6d2" />
