### PR TITLE
[FE] - ios FCM알림 오도록 설정 구현 & 데모데이 QA 반영 & 번들 사이즈 줄이기

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DingDong</title>
+    <link rel="manifest" href="/manifest.json" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <link rel="icon" href="https://i.ibb.co/vxBm7M8G/2025-02-21-7-11-37.png" />
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DingDong</title>
+    <link rel="icon" href="https://i.ibb.co/vxBm7M8G/2025-02-21-7-11-37.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "딩동",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "https://i.ibb.co/vxBm7M8G/2025-02-21-7-11-37.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/components/Modal/styles.ts
+++ b/src/components/Modal/styles.ts
@@ -5,55 +5,56 @@ import {CTAButtonB} from "@/styles/buttons.ts";
 
 
 export const Backdrop = styled.div`
-    position: fixed;
-    z-index: 9999;
+  position: fixed;
+  z-index: 9999;
     top:0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
     background: rgba(0, 0, 0, 0.50);
 `
 
 export const ModalWrapper = styled.div`
-    width: 315px;
+  width: 315px;
 
-    border-radius: 12px;
-    background: ${colors.gray0};
+  border-radius: 12px;
+  background: ${colors.gray0};
 `
 
 export const ModalInfo = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 20px;
-    width: 100%;
-    padding: 32px 20px;
-    text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+  padding: 32px 20px;
+  text-align: center;
 `
 
 export const ModalTitle = styled(Heading1Bold)`
-    color: ${colors.gray100};
-`
+  color: ${colors.gray100};
+  white-space: break-spaces;
+`;
 
 export const ModalText = styled(Body1Regular)`
-    color: ${colors.gray70};
+  color: ${colors.gray70};
 `
 
 export const ButtonBox = styled.div`
-    display: flex;
-    width: 100%;
-    padding: 0 20px 20px;
-    justify-content: space-between;
-    gap: 20px;
+  display: flex;
+  width: 100%;
+  padding: 0 20px 20px;
+  justify-content: space-between;
+  gap: 20px;
 `
 
 export const Button = styled(CTAButtonB)`
-    flex: 1;
+  flex: 1;
 `
 
 export const ButtonText = styled(Body1Regular)`
-    color: ${colors.gray100};
+  color: ${colors.gray100};
 `

--- a/src/pages/Auth/Login/index.tsx
+++ b/src/pages/Auth/Login/index.tsx
@@ -15,8 +15,6 @@ import { AxiosError } from "axios";
 import { mountModal } from "@/components/Loading";
 import Modal from "@/components/Modal";
 
-import { handleAllowNotification } from "@/webPushNotification/handleAllowNotification";
-
 const Login = () => {
   const navigate = useNavigate();
   const { postLoginMutation } = useLogin();
@@ -50,12 +48,12 @@ const Login = () => {
       />
     );
   };
+
   const loginHandler = () => {
     const loginFormData = { email, password };
     postLoginMutation(loginFormData, {
       onSuccess: () => {
         navigate("/home");
-        handleAllowNotification();
       },
       onError: (error: Error) => {
         const err = error as AxiosError<{ message: string }>;
@@ -67,6 +65,7 @@ const Login = () => {
       },
     });
   };
+
   return (
     <>
       <PopHeader text="" />

--- a/src/pages/Auth/LoginHome/index.tsx
+++ b/src/pages/Auth/LoginHome/index.tsx
@@ -4,6 +4,10 @@ import animationData from "@/assets/lottie/busLoadingAnimation.json";
 import { useNavigate } from "react-router-dom";
 import DingdongLogoIcon from "@/components/designSystem/Icons/LoginHome/DingdongLogoIcon";
 import SolidButton from "@/components/designSystem/Button/SolidButton";
+import { mountModal } from "@/components/Loading";
+import Modal from "@/components/Modal";
+import { useEffect } from "react";
+import { handleAllowNotification } from "@/webPushNotification/handleAllowNotification";
 
 const defaultOptions = {
   loop: true,
@@ -16,6 +20,36 @@ const defaultOptions = {
 
 export default function LoginHomeScreen() {
   const navigate = useNavigate();
+
+  const renderWebPushNotificationModal = () => {
+    const { render, unmountModal } = mountModal();
+
+    render(
+      <Modal
+        title={["🔔딩동 푸시 알림을 \n 허용해 주세요"]}
+        text={[""]}
+        leftButton={{
+          text: "설정하기",
+          onClick: () => {
+            unmountModal();
+            handleAllowNotification(); // 알림 처리 함수 실행
+          },
+        }}
+      />
+    );
+  };
+
+  const loginButtonHandler = () => {
+    navigate("/login");
+  };
+
+  useEffect(() => {
+    if (Notification.permission !== "granted") {
+      renderWebPushNotificationModal();
+      handleAllowNotification();
+    }
+  }, []);
+
   return (
     <LoginHome.Container>
       <LoginHome.Logo>
@@ -26,7 +60,7 @@ export default function LoginHomeScreen() {
         <Lottie width={140} height={105} options={defaultOptions} />
       </LoginHome.IconWrapper>
       <LoginHome.ButtonWrapper>
-        <SolidButton onClick={() => navigate("/login")} text={"로그인 하기"} />
+        <SolidButton onClick={loginButtonHandler} text={"로그인 하기"} />
         <LoginHome.SignUpButton onClick={() => navigate("/signup")}>
           이메일로 회원가입
         </LoginHome.SignUpButton>

--- a/src/pages/Auth/Signup/UserInfo/index.tsx
+++ b/src/pages/Auth/Signup/UserInfo/index.tsx
@@ -20,7 +20,6 @@ import {
 } from "../../hooks/useAddressToCoordinate";
 
 import useKakaoLoader from "@/hooks/useKakaoLoader/useKakaoLoader";
-import { handleAllowNotification } from "@/webPushNotification/handleAllowNotification";
 import { AxiosError } from "axios";
 import { mountModal } from "@/components/Loading";
 import Modal from "@/components/Modal";
@@ -129,7 +128,6 @@ export default function UserInfoSignup() {
     postUserInfoMutation(finalUserInfo, {
       onSuccess: () => {
         navigate("/home");
-        handleAllowNotification(); // 웹 푸시 알림 셋팅을 위한 요청.
       },
       onError: (error: Error) => {
         const err = error as AxiosError<{ message: string }>;

--- a/src/pages/BusBooking/CustomRouteBooking/components/CalendarView/index.tsx
+++ b/src/pages/BusBooking/CustomRouteBooking/components/CalendarView/index.tsx
@@ -78,7 +78,7 @@ export default function CalendarView({
       );
       setRecommendationDates(finalRecommendationDates);
     }
-  }, [TimeTableRecommendationArray, currentMonthIndex]);
+  }, [TimeTableRecommendationArray, currentMonthIndex, commuteType]);
 
   const makingTimeTableSuggestion = () => {
     const { render, unmountModal } = mountModal();

--- a/src/pages/BusBooking/CustomRouteBooking/page.tsx
+++ b/src/pages/BusBooking/CustomRouteBooking/page.tsx
@@ -106,14 +106,14 @@ export default function CustomRouteBooking() {
           <DetailText>탑승권은 2일 후부터 예매 가능해요.</DetailText>
         </InfoTextBox>
 
-        <TotalEditableViewButton>
+        <TotalEditableViewButton
+          onClick={() => {
+            setTimeViewModalOpen(true);
+            setOverlayBottomModalType("editable");
+          }}
+        >
           <ButtonTitle>선택한 일정</ButtonTitle>
-          <CountViewBox
-            onClick={() => {
-              setTimeViewModalOpen(true);
-              setOverlayBottomModalType("editable");
-            }}
-          >
+          <CountViewBox>
             {/* 전체 일정을 들고오기. 그 중 빠른 일자를 앞으로. 없으면- */}
             <ScheduleCount>
               {cachedSelectedTimeSchedules.length > 0

--- a/src/pages/BusBooking/CustomRouteBooking/page.tsx
+++ b/src/pages/BusBooking/CustomRouteBooking/page.tsx
@@ -27,7 +27,7 @@ import { convertIsoToDateObject } from "@/utils/calendar/timeViewBottomModalUtil
 import { mountModal } from "@/components/Loading";
 import Modal from "@/components/Modal";
 import { useLoaderData, useNavigate } from "react-router-dom";
-// const { render, unmountModal } = mountModal();
+
 export default function CustomRouteBooking() {
   const [selectedTimeSchedule, dispatch] = useReducer(timeScheduleReducer, {});
   const navigate = useNavigate();

--- a/src/pages/TimetableManagement/components/TimePicker/index.tsx
+++ b/src/pages/TimetableManagement/components/TimePicker/index.tsx
@@ -1,61 +1,68 @@
 import TimePickerWheel, {TimeWheelHandle} from "@/components/TimePickerWheel";
 import {
-    Backdrop,
-    ButtonWrapper,
+  Backdrop,
+  ButtonWrapper,
     LeftButton, LeftText,
     Modal, RightButton, RightText,
     Title
 } from "@/pages/TimetableManagement/components/TimePicker/styles.ts";
-import {Dispatch, SetStateAction, useEffect, useRef, useState} from "react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 
 interface TimePickerProps {
     unmountModal: () => void
-    timeState: string;
-    setTimeState: Dispatch<SetStateAction<string>>;
+  timeState: string;
+  setTimeState: Dispatch<SetStateAction<string>>;
 }
 export default function TimePicker({unmountModal, timeState, setTimeState}: TimePickerProps) {
-    const [isMount, setIsMount] = useState(false);
+  const [isMount, setIsMount] = useState(false);
     const timeWheelRef = useRef<TimeWheelHandle>(null)
 
-    useEffect(() => {
-        setIsMount(true);
-    }, []);
+  useEffect(() => {
+    setIsMount(true);
+  }, []);
 
-    const unmountModalTimer = () => {
-        if (timeWheelRef.current) {
-            const {amPm, hour, minute} = timeWheelRef.current.getSelectedTime()
-            const hour24 = (amPm === '오후' ? +hour + 12 : +hour).toString().padStart(2, '0');
-            setTimeState(`${hour24}:${minute}`)
-        }
-        setIsMount(false);
-        setTimeout(() => unmountModal(), 200);
+  const unmountModalTimer = () => {
+    if (timeWheelRef.current) {
+      const { amPm, hour, minute } = timeWheelRef.current.getSelectedTime();
+      const hour24 = (
+        amPm === "오후" && +hour !== 12
+          ? +hour + 12
+          : amPm === "오전" && +hour === 12
+          ? 0
+          : +hour
+      )
+        .toString()
+        .padStart(2, "0");
+      setTimeState(`${hour24}:${minute}`);
     }
+    setIsMount(false);
+    setTimeout(() => unmountModal(), 200);
+  };
 
-
-    return (
-        <Backdrop>
-            <Modal isMount={isMount}>
+  return (
+    <Backdrop>
+      <Modal isMount={isMount}>
                 <Title>
                     시간을 선택하세요.
                 </Title>
             <TimePickerWheel ref={timeWheelRef} initTime={timeState !== '-' ? {initHour: Number(timeState.split(':')[0]) - 1, initMinute: Number(timeState.split(':')[1]) === 30 ? 1 : 0} : undefined}/>
-            <ButtonWrapper>
+        <ButtonWrapper>
                 <LeftButton onClick={() => {
                     unmountModalTimer()
                 }}>
                     <LeftText>
                         취소
                     </LeftText>
-                </LeftButton>
+          </LeftButton>
                 <RightButton onClick={() => {
                     unmountModalTimer()
                 }}>
                     <RightText>
                         확인
                     </RightText>
-                </RightButton>
-            </ButtonWrapper>
-            </Modal>
-        </Backdrop>
+          </RightButton>
+        </ButtonWrapper>
+      </Modal>
+    </Backdrop>
     )
 }

--- a/src/webPushNotification/settingFCM.ts
+++ b/src/webPushNotification/settingFCM.ts
@@ -2,7 +2,6 @@
 
 import { initializeApp } from "firebase/app";
 import { getMessaging } from "firebase/messaging";
-//import { handleAllowNotification } from "./handleAllowNotification";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,18 @@
 // vite.config.ts
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ["react", "react-dom", "react-router-dom"],
+        },
+      },
+    },
+  },
+
   resolve: {
     alias: [
       { find: "@", replacement: "/src" }, // `@`을 `src` 폴더로 매핑


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#326 

## 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
FCM 웹 푸시 알림이 아이폰에서는 알림 허용 창을 확인 할 수 없어서, 구현 방법을 알아보았습니다. 크게 2가지가 필요합니다.
- PWA 셋팅 (manifest.json, html 헤더에 json파일 추가)
- 클릭 이벤트를 통한 알림 허용 요청 처리
- 유저가 홈 화면에 추가

- [x] PWA셋팅 
- [x] 서비스 첫 접속 시  알림 허용 자체 모달을 뜨게 하고, 허용을 한다면 ios 자체 허용 알림이 뜨게 되어 허용하는 방식으로 구현
     - https에서만 확인할 수 있으므로, 배포가 되어야 작동여부를 볼 수 있을 것 같습니다.
- [x] 데모데이에서 QA반영 => 시간표 등록 페이지에서 스크롤을 하다 오후 12:00 가 24:00로 바뀌는 문제( 조건문만 제가 대신 변경했습니다)
- [x] 등하교 전환시 시간표 추천 시간이 다른 시간으로 반영되는 문제 해결.
- [x] 빌드 시, 번들 사이즈가 700KB가 넘었는데 500대로 줄였습니다. 청크로 나누어서 필요한 라이브러리 병렬 로딩시 좀 더 개선이 되지 않았을까 생각합니다.
## 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
