### PR TITLE
[FE] - FCM 알림 ios 적용 처리 :  ios 브라우저 화면에서 서비스가 흰화면으로 보이는 문제 해결

### DIFF
--- a/src/pages/Auth/LoginHome/index.tsx
+++ b/src/pages/Auth/LoginHome/index.tsx
@@ -8,6 +8,7 @@ import { mountModal } from "@/components/Loading";
 import Modal from "@/components/Modal";
 import { useEffect } from "react";
 import { handleAllowNotification } from "@/webPushNotification/handleAllowNotification";
+import { isNotificationSupported } from "@/webPushNotification/settingFCM";
 
 const defaultOptions = {
   loop: true,
@@ -44,6 +45,9 @@ export default function LoginHomeScreen() {
   };
 
   useEffect(() => {
+    if (!isNotificationSupported) {
+      return;
+    }
     if (Notification.permission !== "granted") {
       renderWebPushNotificationModal();
       handleAllowNotification();

--- a/src/webPushNotification/settingFCM.ts
+++ b/src/webPushNotification/settingFCM.ts
@@ -15,19 +15,18 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
-// Initialize Firebase
+// Firebase 초기화
 export const app = initializeApp(firebaseConfig);
-// export const messaging = getMessaging(app);
 
-// 서비스 워커 확인 후 FCM 초기화
-// messaging을 먼저 선언하고, 이후에 조건에 따라 설정
 export let messaging: Messaging | undefined = undefined;
 
-const isPWAOrNotIphone = "serviceWorker" in navigator;
-if (isPWAOrNotIphone) {
-  // ios의 경우 PWA 라면 서비스 워커 지원 가능. 일반 ios 에서 브라우저라면 지원 안되어서 막기.
-  console.log("서비스 워커 지원됨, FCM 사용 가능");
+// Notification API와 서비스 워커 지원 여부 체크
+export const isNotificationSupported = "Notification" in window;
+const isServiceWorkerSupported = "serviceWorker" in navigator;
+
+if (isNotificationSupported && isServiceWorkerSupported) {
+  console.log("서비스 워커와 Notification 지원됨, FCM 사용 가능");
   messaging = getMessaging(app);
 } else {
-  console.log("서비스 워커 미지원, FCM 비활성화");
+  console.log("Notification 또는 서비스 워커 미지원, FCM 비활성화");
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
  
#326 
문제 : ios 브라우저에서 서비스 링크 접속시 흰화면이 나오는 문제가 발생했습니다.
원인을 찾고 해결하고자 수정을 했습니다.
## 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- [x] ios 브라우저는 서비스 워커는 지원, notification 객체는 지원X 므로, 따로 조건문 처리를 추가.
- [x] 바로 객체에 접근하여, undefined인데 접근이 되어 에러가 났던 것이 원인. PWA인지 체크하는 것이 아닌 Nofication 객체 자체가 사용 되는 환경인지 확인이 필수!

## 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->




