### PR TITLE
[BE] count query에서 SELECT문이 빠졌던 것 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/repository/ReservationQueryRepository.java
@@ -56,6 +56,7 @@ public interface ReservationQueryRepository extends JpaRepository<Reservation, L
        CASE WHEN :sort = 1 THEN r.startDate END ASC
     """,
     countQuery = """
+    SELECT COUNT(DISTINCT r.id)
     FROM Reservation r
     LEFT JOIN Ticket t ON r.id = t.reservation.id
     LEFT JOIN BusStop bs ON t.busStopId = bs.id


### PR DESCRIPTION
## 버그&해결
- countquery에서, SELECT COUNT(r)이 실수로 빠졌던 버그 수정