### PR TITLE
[BE] 함께 타기 예약이 확정되면, 세마포어를 놓지 않고 계속 유지하도록 변경

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
@@ -10,8 +10,8 @@ import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationStatus;
 import com.ddbb.dingdong.domain.reservation.entity.vo.ReservationType;
 import com.ddbb.dingdong.domain.reservation.repository.BusStopRepository;
 import com.ddbb.dingdong.domain.reservation.service.ReservationConcurrencyManager;
-import com.ddbb.dingdong.domain.reservation.service.error.ReservationErrors;
 import com.ddbb.dingdong.domain.reservation.service.ReservationManagement;
+import com.ddbb.dingdong.domain.reservation.service.error.ReservationErrors;
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
 import com.ddbb.dingdong.domain.transportation.entity.BusStop;
 import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
@@ -46,6 +46,11 @@ public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReser
         saveToken(param);
 
         return null;
+    }
+
+    private void removeWaitingCache(Param param) {
+        Long userId = param.getReservationInfo().userId;
+        reservationConcurrencyManager.removeUser(userId);
     }
 
     private void saveToken(Param param) {
@@ -124,7 +129,7 @@ public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReser
 
             reservationManagement.reserve(reservation);
         } finally {
-            reservationConcurrencyManager.removeUserInCache(userId);
+            reservationConcurrencyManager.removeUser(userId);
             reservationConcurrencyManager.unlockBusSchedule(busScheduleId);
         }
     }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationConcurrencyManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationConcurrencyManager.java
@@ -54,7 +54,7 @@ public class ReservationConcurrencyManager {
         if(busScheduleId.equals(cachedBusScheduleId)) {
             return true;
         } else if (cachedBusScheduleId != null) {
-            removeUserInCache(userId);
+            removeUserWithReleaseSemaphore(userId);
         }
 
         Semaphore semaphore = (Semaphore) cache.get(Map.entry(busScheduleId, Type.SEMAPHORE));
@@ -79,7 +79,13 @@ public class ReservationConcurrencyManager {
         return null;
     }
 
-    public Long removeUserInCache(Long userId) {
+    public Long removeUserWithReleaseSemaphore(Long userId) {
+        Object value = cache.removeWithTask(userId);
+        if (value != null) return (Long) value;
+        return null;
+    }
+
+    public Long removeUser(Long userId) {
         Object value = cache.remove(userId);
         if (value != null) return (Long) value;
         return null;

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/cache/SimpleCache.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/cache/SimpleCache.java
@@ -139,7 +139,9 @@ public class SimpleCache  {
      */
     public Object remove(Object key) {
         CacheEntry entry = map.remove(key);
-
+        if (entry != null && System.currentTimeMillis() > entry.expiryTimeMillis) {
+            return null;
+        }
         return entry != null ? entry.value : null;
     }
 

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/cache/SimpleCache.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/cache/SimpleCache.java
@@ -93,7 +93,7 @@ public class SimpleCache  {
     public Object get(Object key) {
         CacheEntry entry = map.get(key);
         if (entry != null && System.currentTimeMillis() > entry.expiryTimeMillis) {
-            remove(key);
+            removeWithTask(key);
             return null;
         }
         return entry != null ? entry.value : null;
@@ -109,18 +109,18 @@ public class SimpleCache  {
     public boolean containsKey(Object key) {
         CacheEntry entry = map.get(key);
         if (entry != null && System.currentTimeMillis() > entry.expiryTimeMillis) {
-            remove(key);
+            removeWithTask(key);
         }
         return entry != null;
     }
 
     /**
      * 캐시에서 키에 해당하는 값을 삭제합니다.
-     *
+     * 삭제하면서, entry에 등록된 task를 실행합니다.
      * @param key
      * @return 키에 해당하는 값이 있다면 해당 값, 없다면 {@code null}을 반환합니다.
      */
-    public Object remove(Object key) {
+    public Object removeWithTask(Object key) {
         CacheEntry entry = map.remove(key);
         if (entry != null) {
             if (entry.afterExpiryTask != null) {
@@ -129,6 +129,18 @@ public class SimpleCache  {
             return entry.value;
         }
         return null;
+    }
+
+    /**
+     * 캐시에서 키에 해당하는 값을 삭제합니다.
+     * entry에 등록된 task를 실행하지 않고 삭제합니다.
+     * @param key
+     * @return 키에 해당하는 값이 있다면 해당 값, 없다면 {@code null}을 반환합니다.
+     */
+    public Object remove(Object key) {
+        CacheEntry entry = map.remove(key);
+
+        return entry != null ? entry.value : null;
     }
 
     /**
@@ -142,7 +154,7 @@ public class SimpleCache  {
             log.info("{} entries have been cleaned up in {}ms", getRandomEntries().size(), now);
             if (now >= entry.getValue().expiryTimeMillis) {
                 log.info("clean up cache");
-                remove(entry.getKey());
+                removeWithTask(entry.getKey());
             }
         }
     }


### PR DESCRIPTION
## 문제 상황
- 함께타기에서 예약이 확정되면, 세마포어를 놓지 말아야하는데 세마포어를 놓아서 좌석 수가 제대로 반영이 안되는 버그

## 해결
- 캐시에서 제거될 때 세마포어를 놓는 메소드와, 캐시에서 제거될 때 세마포어를 놓지 않는 메소드를 분기해서 해결하였습니다.