### PR TITLE
[BE] 버스 출발 후 사용자의 예매 및 결제 시도 차단

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StartBusUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StartBusUseCase.java
@@ -13,7 +13,6 @@ import com.ddbb.dingdong.domain.transportation.service.BusErrors;
 import com.ddbb.dingdong.domain.transportation.service.BusPublishService;
 import com.ddbb.dingdong.domain.transportation.service.BusScheduleManagement;
 import com.ddbb.dingdong.domain.transportation.service.dto.UserBusStopTime;
-import com.ddbb.dingdong.infrastructure.cache.SimpleCache;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +32,6 @@ public class StartBusUseCase implements UseCase<StartBusUseCase.Param, Void> {
     private final BusScheduleQueryRepository busScheduleQueryRepository;
     private final BusScheduleManagement busScheduleManagement;
     private final BusScheduleRepository busScheduleRepository;
-    private final SimpleCache simpleCache;
     private final ReservationConcurrencyManager reservationConcurrencyManager;
 
     @Override

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StartBusUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/bus/StartBusUseCase.java
@@ -3,6 +3,7 @@ package com.ddbb.dingdong.application.usecase.bus;
 import com.ddbb.dingdong.application.common.Params;
 import com.ddbb.dingdong.application.common.UseCase;
 import com.ddbb.dingdong.domain.reservation.entity.vo.Direction;
+import com.ddbb.dingdong.domain.reservation.service.ReservationConcurrencyManager;
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
 import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
 import com.ddbb.dingdong.domain.transportation.repository.BusScheduleQueryRepository;
@@ -12,6 +13,7 @@ import com.ddbb.dingdong.domain.transportation.service.BusErrors;
 import com.ddbb.dingdong.domain.transportation.service.BusPublishService;
 import com.ddbb.dingdong.domain.transportation.service.BusScheduleManagement;
 import com.ddbb.dingdong.domain.transportation.service.dto.UserBusStopTime;
+import com.ddbb.dingdong.infrastructure.cache.SimpleCache;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,8 @@ public class StartBusUseCase implements UseCase<StartBusUseCase.Param, Void> {
     private final BusScheduleQueryRepository busScheduleQueryRepository;
     private final BusScheduleManagement busScheduleManagement;
     private final BusScheduleRepository busScheduleRepository;
+    private final SimpleCache simpleCache;
+    private final ReservationConcurrencyManager reservationConcurrencyManager;
 
     @Override
     @Transactional
@@ -63,9 +67,12 @@ public class StartBusUseCase implements UseCase<StartBusUseCase.Param, Void> {
         if(busSchedule.getDirection().equals(Direction.TO_SCHOOL)) {
             busSchedule.setArrivalTime(newUserBusStopTimes.get(newUserBusStopTimes.size() - 1).getTime());
             busScheduleManagement.publishDepartureEvent(newUserBusStopTimes);
-        }else {
+        } else {
             busSchedule.setDepartureTime(now);
         }
+
+        reservationConcurrencyManager.lockBusSchedule(param.busScheduleId);
+        reservationConcurrencyManager.removeSemaphore(param.busScheduleId);
 
         return null;
     }

--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/RequestTogetherReservationUseCase.java
@@ -36,6 +36,7 @@ public class RequestTogetherReservationUseCase implements UseCase<RequestTogethe
         param.validate();
         LocalDateTime hopeTime = extractTimeFromBusSchedule(param);
         checkHasDuplicatedReservation(param.userId, hopeTime);
+
         boolean acquired = false;
         try {
             acquired = acquireSemaphore(param.userId, param.busScheduleId);

--- a/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationConcurrencyManager.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/reservation/service/ReservationConcurrencyManager.java
@@ -1,11 +1,12 @@
 package com.ddbb.dingdong.domain.reservation.service;
 
+import com.ddbb.dingdong.domain.reservation.service.error.ReservationErrors;
 import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
 import com.ddbb.dingdong.domain.transportation.repository.BusScheduleQueryRepository;
 import com.ddbb.dingdong.domain.transportation.repository.projection.BusScheduleIdAndReservedSeatsProjection;
 import com.ddbb.dingdong.domain.transportation.service.BusErrors;
 import com.ddbb.dingdong.infrastructure.cache.SimpleCache;
-import com.ddbb.dingdong.infrastructure.lock.ChannelLock;
+import com.ddbb.dingdong.infrastructure.lock.StoppableSemaphore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -14,9 +15,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -24,26 +23,26 @@ import java.util.concurrent.TimeUnit;
 public class ReservationConcurrencyManager {
     private final SimpleCache cache;
     private final BusScheduleQueryRepository busScheduleQueryRepository;
-    public enum Type { SEMAPHORE, LOCK };
     private static final int EXPIRATION_TIME_MINUTES = 5;
     private static final int EXPIRATION_TIME_DAYS = 2;
+    
+    private static final String CACHE_ID_BUS_SCHEDULE = "busSchedule";
+    private static final String CACHE_ID_USER = "user";
 
     @EventListener(ApplicationReadyEvent.class)
     protected void init() {
         List<BusScheduleIdAndReservedSeatsProjection> projections = busScheduleQueryRepository.queryReadyBusSchedules();
         for (BusScheduleIdAndReservedSeatsProjection projection : projections) {
-            cache.put(Map.entry(projection.getBusScheduleId(), Type.SEMAPHORE), new Semaphore(15 - projection.getReservedSeats(), true), Duration.ofDays(EXPIRATION_TIME_DAYS));
-            cache.put(Map.entry(projection.getBusScheduleId(), Type.LOCK), new ChannelLock(), Duration.ofDays(EXPIRATION_TIME_DAYS));
+            cache.put(String.format(CACHE_ID_BUS_SCHEDULE + ":%d", projection.getBusScheduleId()), new StoppableSemaphore(15 - projection.getReservedSeats(), true), Duration.ofDays(EXPIRATION_TIME_DAYS));
         }
     }
 
     public void initReservationData(BusSchedule busSchedule) {
-        cache.put(Map.entry(busSchedule.getId(), Type.SEMAPHORE), new Semaphore(busSchedule.getRemainingSeats(), true), Duration.ofDays(EXPIRATION_TIME_DAYS));
-        cache.put(Map.entry(busSchedule.getId(), Type.LOCK), new ChannelLock(), Duration.ofDays(EXPIRATION_TIME_DAYS));
+        cache.put(String.format(CACHE_ID_BUS_SCHEDULE + ":%d",busSchedule.getId()), new StoppableSemaphore(busSchedule.getRemainingSeats(), true), Duration.ofDays(EXPIRATION_TIME_DAYS));
     }
 
     public void addUserToTimeLimitCache(Long userId, Long busScheduleId) {
-        cache.put(userId, busScheduleId, () -> {
+        cache.put(String.format(CACHE_ID_USER + ":%d", userId), busScheduleId, () -> {
             releaseSemaphore(busScheduleId);
         }, Duration.ofMinutes(EXPIRATION_TIME_MINUTES));
     }
@@ -57,9 +56,11 @@ public class ReservationConcurrencyManager {
             removeUserWithReleaseSemaphore(userId);
         }
 
-        Semaphore semaphore = (Semaphore) cache.get(Map.entry(busScheduleId, Type.SEMAPHORE));
+        StoppableSemaphore semaphore = (StoppableSemaphore) cache.get(String.format(CACHE_ID_BUS_SCHEDULE + ":%d", busScheduleId));
         try {
-            if (!semaphore.tryAcquire(0, TimeUnit.SECONDS)) {
+            if (semaphore == null) {
+                throw ReservationErrors.EXPIRED_RESERVATION_DATE.toException();
+            } else if (!semaphore.tryAcquire()) {
                 throw new InterruptedException();
             }
             return true;
@@ -69,40 +70,42 @@ public class ReservationConcurrencyManager {
     }
 
     public void releaseSemaphore(Long busScheduleId) {
-        Semaphore semaphore = (Semaphore) cache.get(Map.entry(busScheduleId, Type.SEMAPHORE));
-        semaphore.release();
+        StoppableSemaphore semaphore = (StoppableSemaphore) cache.get(String.format(CACHE_ID_BUS_SCHEDULE + ":%d", busScheduleId));
+        if (semaphore != null) {
+            semaphore.release();
+        }
     }
 
     public Long getUserInCache(Long userId) {
-        Object value = cache.get(userId);
+        Object value = cache.get(String.format(CACHE_ID_USER + ":%d", userId));
         if (value != null) return (Long) value;
         return null;
     }
 
     public Long removeUserWithReleaseSemaphore(Long userId) {
-        Object value = cache.removeWithTask(userId);
+        Object value = cache.removeWithTask(String.format(CACHE_ID_USER + ":%d", userId));
         if (value != null) return (Long) value;
         return null;
     }
 
     public Long removeUser(Long userId) {
-        Object value = cache.remove(userId);
+        Object value = cache.remove(String.format(CACHE_ID_USER + ":%d", userId));
         if (value != null) return (Long) value;
         return null;
     }
 
-    public boolean lockBusSchedule(Long busScheduleId) {
-        ChannelLock lock = (ChannelLock) cache.get(Map.entry(busScheduleId, Type.LOCK));
-        return lock.entryLock();
+    public void lockBusSchedule(Long busScheduleId) {
+        StoppableSemaphore lock = (StoppableSemaphore) cache.get(String.format(CACHE_ID_BUS_SCHEDULE + ":%d", busScheduleId));
+        lock.stop();
     }
 
-    public void unlockBusSchedule(Long busScheduleId) {
-        ChannelLock lock = (ChannelLock) cache.get(Map.entry(busScheduleId, Type.LOCK));
-        lock.unlock();
+    public void removeSemaphore(Long busScheduleId) {
+        cache.remove(String.format(CACHE_ID_BUS_SCHEDULE + ":%d", busScheduleId));
     }
 
     public int getRemainingSeats(Long busScheduleId) {
-        Semaphore semaphore = (Semaphore) cache.get(Map.entry(busScheduleId, Type.SEMAPHORE));
+        Semaphore semaphore = (Semaphore) cache.get(String.format(CACHE_ID_BUS_SCHEDULE + ":%d", busScheduleId));
         return semaphore.availablePermits();
     }
+
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -48,6 +48,21 @@ fcm:
     silent: ${FCM_SILENT}
     requireInteraction: ${FCM_REQUIRE_INTERACTION}
     link: ${FCM_TOUCH_LINK}
+    image: ${FCM_IMAGE}
+    icon: ${FCM_ICON}
+    badge: ${FCM_BADGE}
+
+    message:
+        allocate:
+            success:
+                title: ${ALLOCATE_SUCCESS_TITLE}
+                content: ${ALLOCATE_SUCCESS_CONTENT}
+            fail:
+                title: ${ALLOCATE_FAIL_TITLE}
+                content: ${ALLOCATE_FAIL_CONTENT}
+        bus:
+            start:
+                title: ${BUS_START_TITLE}
 
 logging:
     level:


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- [ ] #359 
## 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- [ ] `StoppableSemaphore`를 이용하여 차단 로직을 구성했습니다.
- [ ] `SimpleCache` 내부 busScheduleId, userId를 태그를 붙여 관리하도록 수정하여 단일 키로도 접근할 수 있도록 수정했습니다.

## 스크린샷(선택)
<!-- 스크린샷
이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="395" alt="스크린샷 2025-02-24 오후 6 03 52" src="https://github.com/user-attachments/assets/76b41102-056f-471c-a0f0-2cd35317770a" />