### PR TITLE
[BE] 소켓 전송 최적화 및 메시지 추가, 시뮬레이션 버그 수정

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/notification/service/NotificationEventListener.java
@@ -47,7 +47,7 @@ public class NotificationEventListener {
     protected void sendAllocationFailNotification(AllocationFailedEvent event) {
         notificationManagement.sendNotification(NotificationType.ALLOCATION_FAILED, event.getUserId(), event.getReservationId(), TICKET_PRICE);
         socketMessageSender.sendMessage(
-                event.getUserId(), String.format(ALARM_SOCKET_MSG + "_%d", event.getReservationId()), 3
+                event.getUserId(), String.format(ALARM_SOCKET_MSG + "_fail_%d", event.getReservationId()), 3
         );
     }
 

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusPublishService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusPublishService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.geo.Point;
 import org.springframework.stereotype.Service;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -26,8 +27,8 @@ public class BusPublishService {
             Long initialDelay,
             TimeUnit timeUnit
     ) {
-        Supplier<Point> supplier =  busSimulatorFactory.create(busScheduleId);
-        SubmissionPublisher<Point> publisher = new PeriodicBusPublisher<>(manager, busScheduleId, supplier, interval, initialDelay, timeUnit);
+        Supplier<ByteBuffer> supplier =  busSimulatorFactory.create(busScheduleId);
+        SubmissionPublisher<ByteBuffer> publisher = new PeriodicBusPublisher<>(manager, busScheduleId, supplier, interval, initialDelay, timeUnit);
         manager.addPublishers(busScheduleId, publisher);
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusSubscribeService.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/service/BusSubscribeService.java
@@ -11,6 +11,8 @@ import org.springframework.data.geo.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.nio.ByteBuffer;
+
 @Service
 @RequiredArgsConstructor
 public class BusSubscribeService {
@@ -22,7 +24,7 @@ public class BusSubscribeService {
         if (session == null) {
             throw new DomainException(BusErrors.NO_SOCKET_CONNECTION);
         }
-        CancelableSubscriber<Point> subscriber = new SocketSubscriber(busId, userId, session, busSubscriptionManager);
+        CancelableSubscriber<ByteBuffer> subscriber = new SocketSubscriber(busId, userId, session, busSubscriptionManager);
         busSubscriptionManager.subscribe(busId, new UserSubscription(userId, subscriber));
     }
 

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/UserSubscription.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/UserSubscription.java
@@ -5,11 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.geo.Point;
 
+import java.nio.ByteBuffer;
+
 @Getter
 @AllArgsConstructor
 public class UserSubscription implements Comparable<UserSubscription> {
     private Long userId;
-    private CancelableSubscriber<Point> subscriber;
+    private CancelableSubscriber<ByteBuffer> subscriber;
 
     @Override
     public boolean equals(Object obj) {

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/publisher/PeriodicBusPublisher.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/publisher/PeriodicBusPublisher.java
@@ -17,7 +17,7 @@ public class PeriodicBusPublisher<T> extends SubmissionPublisher<T> {
             BusSubscriptionManager manager, long busId,
             Supplier<T> supplier, long period, long initialDelay, TimeUnit unit
     ) {
-        super();
+        super(Executors.newSingleThreadExecutor(), 1);
         this.manager = manager;
         this.busId = busId;
         this.scheduler = Executors.newSingleThreadScheduledExecutor();

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/source/BusSimulator.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/source/BusSimulator.java
@@ -2,10 +2,12 @@ package com.ddbb.dingdong.infrastructure.bus.subscription.source;
 
 import org.springframework.data.geo.Point;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.function.Supplier;
 
-public class BusSimulator implements Supplier<Point> {
+public class BusSimulator implements Supplier<ByteBuffer> {
     private final List<Point> simulatedPoints;
     private int currentPosition = 0;
 
@@ -14,10 +16,15 @@ public class BusSimulator implements Supplier<Point> {
     }
 
     @Override
-    public Point get() {
+    public ByteBuffer get() {
         if (currentPosition >= simulatedPoints.size()) {
             return null;
         }
-        return simulatedPoints.get(currentPosition++);
+        Point point = simulatedPoints.get(currentPosition++);
+        ByteBuffer buffer = ByteBuffer.allocate(16);
+        buffer.order(ByteOrder.BIG_ENDIAN);
+        buffer.putDouble(point.getX());
+        buffer.putDouble(point.getY());
+        return buffer.flip();
     }
 }

--- a/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/subscriber/StubConsoleSubscriber.java
+++ b/backend/src/main/java/com/ddbb/dingdong/infrastructure/bus/subscription/subscriber/StubConsoleSubscriber.java
@@ -3,10 +3,11 @@ package com.ddbb.dingdong.infrastructure.bus.subscription.subscriber;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.geo.Point;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.Flow;
 
 @Slf4j
-public class StubConsoleSubscriber extends CancelableSubscriber<Point> {
+public class StubConsoleSubscriber extends CancelableSubscriber<ByteBuffer> {
     @Override
     public void onSubscribe(Flow.Subscription subscription) {
         this.subscription = subscription;
@@ -14,7 +15,7 @@ public class StubConsoleSubscriber extends CancelableSubscriber<Point> {
     }
 
     @Override
-    public void onNext(Point item) {
+    public void onNext(ByteBuffer item) {
         System.out.println(item);
     }
 


### PR DESCRIPTION
## 관련 이슈
- #355 

## 구현 사항
- 버스 시뮬레이터가 중간 위치 부터 출발하는 버그를 수정했습니다
- 버스 위치 데이터를 바이너리 형식으로 전송하도록 변경했습니다.
- Subscriber의 구독 버퍼 크기를 1로 줄였습니다. (데이터가 드랍되더라도 최신 데이터가 중요하기 때문)