### PR TITLE
[BE] Hotfix: 버스 스케쥴 테이블 내 남은 좌석 수 감소 시키는 쿼리문 삭제

### DIFF
--- a/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
+++ b/backend/src/main/java/com/ddbb/dingdong/application/usecase/reservation/MakeTogetherReservationUseCase.java
@@ -16,7 +16,6 @@ import com.ddbb.dingdong.domain.transportation.entity.BusSchedule;
 import com.ddbb.dingdong.domain.transportation.entity.BusStop;
 import com.ddbb.dingdong.domain.transportation.entity.vo.OperationStatus;
 import com.ddbb.dingdong.domain.transportation.repository.BusScheduleRepository;
-import com.ddbb.dingdong.domain.transportation.service.BusErrors;
 import com.ddbb.dingdong.infrastructure.auth.encrypt.token.TokenManager;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
@@ -120,9 +119,6 @@ public class MakeTogetherReservationUseCase implements UseCase<MakeTogetherReser
         Ticket ticket = new Ticket(null, busScheduleId, busStopId, reservation);
 
         reservation.issueTicket(ticket);
-        if (busScheduleRepository.issueTicket(busScheduleId) == 0) {
-            throw BusErrors.NO_SEATS.toException();
-        }
 
         reservationManagement.reserve(reservation);
         reservationConcurrencyManager.removeUser(userId);

--- a/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleRepository.java
+++ b/backend/src/main/java/com/ddbb/dingdong/domain/transportation/repository/BusScheduleRepository.java
@@ -25,8 +25,4 @@ public interface BusScheduleRepository extends JpaRepository<BusSchedule, Long> 
             @Param("busScheduleId") Long busScheduleId,
             @Param("status") OperationStatus status
     );
-
-    @Modifying
-    @Query("UPDATE BusSchedule b SET b.remainingSeats = b.remainingSeats - 1 WHERE b.id = :busScheduleId AND b.remainingSeats > 0")
-    int issueTicket(@Param("busScheduleId") Long busScheduleId);
 }


### PR DESCRIPTION
초기에 티켓의 수를 가져와 남은 좌석 수를 판단하므로 필요없는 쿼리문이기에 삭제했습니다.