### PR TITLE
[FE] - fcm 푸시 알림을 클릭했을 때, 알림 내역 화면으로 이동하도록 검증 조건문 추가.

### DIFF
--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -23,9 +23,15 @@ self.addEventListener("push", function (e) {
 
 // push 이벤트의 객체가 notificationclick 이벤트 객체에 부모.
 // 즉, 여기서 notificationclick 이벤트 객체에 값이 전이된다.
+const NOTIFICATION_URL = "https://www.ding-dong-bus.shop/notification";
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const urlToOpen = event.notification.data;
-  event.waitUntil(self.clients.openWindow(urlToOpen));
+  const urlToOpen = event.notification.data.url;
+  // URL이 유효한지 확인
+  if (urlToOpen) {
+    event.waitUntil(self.clients.openWindow(urlToOpen));
+  } else {
+    event.waitUntil(self.clients.openWindow(NOTIFICATION_URL));
+  }
 });

--- a/frontend/src/pages/Auth/Components/Dropdown/index.tsx
+++ b/frontend/src/pages/Auth/Components/Dropdown/index.tsx
@@ -5,6 +5,7 @@ import {
   DropdownContainer,
   DropdownItem,
   DropdownList,
+  SchoolName,
 } from "./styles";
 import ChevronRightIcon from "@/components/designSystem/Icons/ChevronRightIcon";
 type SchoolType = {
@@ -25,7 +26,7 @@ export default function SchoolDropdown({
   return (
     <DropdownContainer>
       <DropdownButton onClick={() => setIsOpen(!isOpen)}>
-        <div>{selected}</div>
+        <SchoolName>{selected}</SchoolName>
         <ChevronIconWrapper>
           <ChevronRightIcon />
         </ChevronIconWrapper>

--- a/frontend/src/pages/Auth/Components/Dropdown/styles.ts
+++ b/frontend/src/pages/Auth/Components/Dropdown/styles.ts
@@ -1,10 +1,13 @@
+import { colors } from "@/styles/colors";
 import styled from "styled-components";
 
 export const DropdownContainer = styled.div`
   position: relative;
   width: 100%;
 `;
-
+export const SchoolName = styled.div`
+  color: ${colors.gray100};
+`;
 export const DropdownButton = styled.button`
   width: 100%;
   padding: 12px;


### PR DESCRIPTION
## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#387 

- url이 혹시 존재하지 않을 때를 대비해서, url 존재하지 않는다면 URL 링크로 이동하도록 수정했습니다.
- +) ios 파란색 폰트 부분이 나오는 문제 -> gray100 색을 추가하여 수정했습니다.

## 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- [x] 푸시 알림 창 클릭시 -> 알림내역 이동이 되도록 수정
- [x] 파란색 글씨 -> gray100 색 지정

## 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


